### PR TITLE
Udp utility + fill with default functions

### DIFF
--- a/examples/l3-multi-destinations.lua
+++ b/examples/l3-multi-destinations.lua
@@ -33,8 +33,7 @@ end
 function loadSlave(port, queue, minA, numIPs)
 	--- parse and check ip addresses
 	-- min UDP packet size for IPv6 is 66 bytes
-	-- 4 bytes subtracted as the CRC gets appended by the NIC
-	local packetLen = 66 - 4 
+	local packetLen = 66
 	local ipv4 = true
 	local minIP
 
@@ -66,6 +65,12 @@ function loadSlave(port, queue, minA, numIPs)
 			pkt = buf:getUDP6Packet()
 		end
 
+		pkt:fill{ ethSrc="90:e2:ba:2c:cb:02", ethDst="90:e2:ba:35:b5:81", 
+				  ipSrc="192.168.1.1", 
+				  ip6Src="fd06::1", 
+				  pktLength=packetLen }
+
+--[[
 		--ethernet header
 		pkt.eth.dst:setString("90:e2:ba:35:b5:81")
 		pkt.eth.src:setString("90:e2:ba:2c:cb:02")
@@ -105,6 +110,7 @@ function loadSlave(port, queue, minA, numIPs)
 			pkt.udp.len = hton16(packetLen - 54)
 		end
 		pkt.udp.cs = 0
+		--]]
 	end)
 
 	local lastPrint = dpdk.getTime()

--- a/lua/include/packet.lua
+++ b/lua/include/packet.lua
@@ -214,11 +214,16 @@ function ip4Header:setProtocol(int)
 	self.protocol = int
 end
 
+function ip4Header:setChecksum(int)
+	int = int or 0
+	self.cs = hton16(int)
+end
+
 --- Calculate and set the IPv4 header checksum
 -- If possible use checksum offloading (see pkt:offloadUdpChecksum) instead
 function ip4Header:calculateChecksum()
-	self.cs = 0 		-- just to be sure (packet may be reused) 
-	self.cs = checksum(self, 20)
+	self:setChecksum() -- just to be sure (packet may be reused); must be 0 
+    self:setChecksum(checksum(self, 20))
 end
 
 function ip4Header:setDst(int)

--- a/lua/include/packet.lua
+++ b/lua/include/packet.lua
@@ -265,8 +265,6 @@ function ip4Addr:getString()
 	return ("%d.%d.%d.%d"):format(self.uint8[0], self.uint8[1], self.uint8[2], self.uint8[3])
 end
 
-local udpPacket = {}
-udpPacket.__index = udpPacket
 
 --- Test equality of two IPv4 addresses
 -- @param lhs address in ipv4_address format
@@ -308,12 +306,6 @@ end
 -- @return resulting address in uint32 format
 function ip4Addr:__sub(val)
 	return self + -val
-end
-
---- Calculate and set the UDP header checksum for IPv4 packets
-function udpPacket:calculateUDPChecksum()
-	-- optional, so don't do it
-	self.udp.cs = 0
 end
 
 --- ipv6 packets
@@ -510,23 +502,62 @@ function ip6Addr:getString(doByteSwap)
 end
 
 -- udp
+local udpHeader = {}
+udpHeader.__index = udpHeader
+
+function udpHeader:setSrcPort(int)
+	int = int or 1116
+	self.src = hton16(int)
+end
+
+function udpHeader:setDstPort(int)
+	int = int or 2222
+	self.dst = hton16(int)
+end
+
+function udpHeader:setLength(int)
+	int = int or 28
+	self.len = hton16(int)
+end
+
+function udpHeader:setChecksum(int)
+	int = int or 0
+	self.cs = hton16(int)
+end
+
+
+-- udp packets
+local udpPacket = {}
+udpPacket.__index = udpPacket
+
+--- Calculate and set the UDP header checksum for IPv4 packets
+function udpPacket:calculateUDPChecksum()
+	-- optional, so don't do it
+	self.udp:setChecksum()
+end
+
 local udp6Packet = {}
 udp6Packet.__index = udp6Packet
 
 --- Calculate and set the UDP header checksum for IPv6 packets
 function udp6Packet:calculateUDPChecksum()
 	-- TODO as it is mandatory for IPv6 UDP packets
-	self.udp.cs = 0
+	self.udp:setChecksum()
 end
 
 ffi.metatype("struct mac_address", macAddr)
+ffi.metatype("struct ethernet_packet", etherPacket)
+ffi.metatype("struct ethernet_header", etherHeader)
+
 ffi.metatype("struct ipv4_header", ip4Header)
 ffi.metatype("struct ipv6_header", ip6Header)
 ffi.metatype("union ipv4_address", ip4Addr)
 ffi.metatype("union ipv6_address", ip6Addr)
+
+ffi.metatype("struct udp_header", udpHeader)
+
 ffi.metatype("struct udp_packet", udpPacket)
 ffi.metatype("struct udp_v6_packet", udp6Packet)
+
 ffi.metatype("struct rte_mbuf", pkt)
-ffi.metatype("struct ethernet_packet", etherPacket)
-ffi.metatype("struct ethernet_header", etherHeader)
 

--- a/lua/include/packet.lua
+++ b/lua/include/packet.lua
@@ -15,8 +15,8 @@ local istype = ffi.istype
 local pkt = {}
 pkt.__index = pkt
 
---- Retrieve the time stamp information
--- @return the timestamp or nil if the packet was not time stamped
+--- Retrieve the time stamp information.
+-- @return The timestamp or nil if the packet was not time stamped.
 function pkt:getTimestamp()
 	if bit.bor(self.ol_flags, dpdk.PKT_RX_IEEE1588_TMST) ~= 0 then
 		-- TODO: support timestamps that are stored in registers instead of the rx buffer
@@ -31,6 +31,9 @@ function pkt:getTimestamp()
 end
 
 --- Instruct the NIC to calculate the IP and UDP checksum for this packet.
+-- @param ipv4 Boolean to decide whether the packet uses IPv4 (set to nil/true) or IPv6 (set to anything else).
+-- @param l2_len Length of the layer 2 header in bytes (default 14 bytes for ethernet).
+-- @param l3_len Length of the layer 3 header in bytes (default 20 bytes for IPv4, 40 bytes for IPv6).
 function pkt:offloadUdpChecksum(ipv4, l2_len, l3_len)
 	-- NOTE: this method cannot be moved to the udpPacket class because it doesn't (and can't) know the pktbuf it belongs to
 	ipv4 = ipv4 == nil or ipv4
@@ -54,8 +57,8 @@ local macAddr = {}
 macAddr.__index = macAddr
 local macAddrType = ffi.typeof("struct mac_address")
 
---- Retrieve the MAC address
--- @return address in mac_address format
+--- Retrieve the MAC address.
+-- @return Address in 'struct mac_address' format.
 function macAddr:get()
 	local addr = macAddrType()
 	for i = 0, 5 do
@@ -64,24 +67,24 @@ function macAddr:get()
 	return addr
 end
 
---- Set the MAC address
--- @param addr address in mac_address format
+--- Set the MAC address.
+-- @param addr Address in 'struct mac_address' format.
 function macAddr:set(addr)
 	for i = 0, 5 do
 		self.uint8[i] = addr.uint8[i]
 	end
 end
 
---- Set the MAC address
--- @param mac address in string format
+--- Set the MAC address.
+-- @param mac Address in string format.
 function macAddr:setString(mac)
 	self:set(parseMACAddress(mac))
 end
 
---- Test equality of two MAC addresses
--- @param lhs address in mac_address format
--- @param rhs address in mac_address format
--- @return is equal
+--- Test equality of two MAC addresses.
+-- @param lhs Address in 'struct mac_address' format.
+-- @param rhs Address in 'struct mac_address' format.
+-- @return true if equal, false otherwise.
 function macAddr.__eq(lhs, rhs)
 	local isMAC = istype(macAddrType, lhs) and istype(macAddrType, rhs) 
 	for i = 0, 5 do
@@ -90,8 +93,8 @@ function macAddr.__eq(lhs, rhs)
 	return isMAC
 end
 
--- Retrieve the string representation of an MAC address
--- @return address in string format
+--- Retrieve the string representation of a MAC address.
+-- @return Address in string format.
 function macAddr:getString()
 	return ("%02x:%02x:%02x:%02x:%02x:%02x"):format(
 			self.uint8[0], self.uint8[1], self.uint8[2], 
@@ -104,35 +107,43 @@ end
 local etherHeader = {}
 etherHeader.__index = etherHeader
 
---- Set the destination MAC address
--- @param addr address in mac_address format
+--- Set the destination MAC address.
+-- @param addr Address in 'struct mac_address' format.
 function etherHeader:setDst(addr)
 	self.dst:set(addr)
 end
 
---- Set the source MAC address
--- @param addr address in mac_address format
+--- Set the source MAC address.
+-- @param addr Address in 'struct mac_address' format.
 function etherHeader:setSrc(addr)
 	self.src:set(addr)
 end
 
---- Set the destination MAC address
--- @param str address in string format
+--- Set the destination MAC address.
+-- @param str Address in string format.
 function etherHeader:setDstString(str)
 	self:setDst(parseMACAddress(str))
 end
 
---- Set the source MAC address
--- @param str address in string format
+--- Set the source MAC address.
+-- @param str Address in string format.
 function etherHeader:setSrcString(str)
 	self:setSrc(parseMACAddress(str))
 end
 
+--- Set the EtherType.
+-- @param int EtherType as 16 bit integer.
 function etherHeader:setType(int)
 	int = int or 0x0800 -- ipv4
 	self.type = hton16(int)
 end
 
+--- Set all members of the ethernet header.
+-- Per default, all members are set to default values specified in the respective set function.
+-- Optional named arguments can be used to set a member to a user-provided value.
+-- @param args Table of named arguments. Available arguments: ethSrc, ethDst, ethType
+-- @usage fill() -- only default values
+-- @usage fill{ ethSrc="12:23:34:45:56:67", ethType=0x137 } -- default value for ethDst; ethSrc and ethType user-specified
 function etherHeader:fill(args)
 	self:setSrcString(args.ethSrc or "01:02:03:04:05:06")
 	self:setDstString(args.ethDst or "07:08:09:0a:0b:0c")
@@ -144,8 +155,8 @@ local etherPacketType = ffi.typeof("struct ethernet_packet*")
 local etherPacket = {}
 etherPacket.__index = etherPacket
 
---- Retrieve an ethernet packet
--- @return the packet in ethernet_packet format
+--- Retrieve an ethernet packet.
+-- @return Packet in 'struct ethernet_packet' format
 function pkt:getEthernetPacket()
 	return etherPacketType(self.pkt.data)
 end
@@ -154,8 +165,8 @@ end
 ---ip packets
 local udpPacketType = ffi.typeof("struct udp_packet*")
 
---- Retrieve an IPv4 UDP packet
--- @return the packet in udp_packet format
+--- Retrieve an IPv4 UDP packet.
+-- @return Packet in 'struct udp_packet' format.
 function pkt:getUDPPacket()
 	return udpPacketType(self.pkt.data)
 end
@@ -163,10 +174,8 @@ end
 local ip4Header = {}
 ip4Header.__index = ip4Header
 
--- TODO adjust default values
-
--- @param int ip header version, should always be '4' 
---		  4 bit integer
+--- Set the version.
+-- @param int IP header version as 4 bit integer. Should always be '4'.
 function ip4Header:setVersion(int)
 	int = int or 4
 	int = band(lshift(int, 4), 0xf0) -- fill to 8 bits
@@ -177,8 +186,8 @@ function ip4Header:setVersion(int)
 	self.verihl = bor(old, int)
 end
 
--- @param int length of the ip header (in multiple of 32 bits)
---		  4 bit integer
+--- Set the header length.
+-- @param int Length of the ip header (in multiple of 32 bits) as 4 bit integer. Should always be '5'.
 function ip4Header:setHeaderLength(int)
 	int = int or 5
 	int = band(int, 0x0f)	
@@ -189,64 +198,98 @@ function ip4Header:setHeaderLength(int)
 	self.verihl = bor(old, int)
 end
 
+--- Set the type of service (TOS).
+-- @param int TOS of the ip header as 8 bit integer.
 function ip4Header:setTOS(int)
 	int = int or 0 
 	self.tos = int
 end
 
+--- Set the total length.
+-- @param int Length of the packet excluding layer 2. 16 bit integer.
 function ip4Header:setLength(int)
 	int = int or 48	-- with eth + UDP -> minimum 64
 	self.len = hton16(int)
 end
 
+--- Set the identification.
+-- @param int ID of the ip header as 16 bit integer.
 function ip4Header:setID(int)
 	int = int or 0 
 	self.id = hton16(int)
 end
 
+-- TODO setFlags: 3 bit
+-- Fragment is only 13 bit
+
+--- Set the fragment.
+-- @param int Fragment of the ip header as 16 bit integer.
 function ip4Header:setFragment(int)
 	int = int or 0 
 	self.frag = hton16(int)
 end
 
+--- Set the time-to-live (TTL).
+-- @param int TTL of the ip header as 8 bit integer.
 function ip4Header:setTTL(int)
 	int = int or 64 
 	self.ttl = int
 end
 
+--- Set the next layer protocol.
+-- @param int Next layer protocol of the ip header as 8 bit integer.
 function ip4Header:setProtocol(int)
 	int = int or 0x11 	-- UDP
 	self.protocol = int
 end
 
+--- Set the checksum.
+-- @param int Checksum of the ip header as 16 bit integer.
+-- @see ip4Header:calculateChecksum()
+-- @see pkt:offloadUdpChecksum(ipv4, l2_len, l3_len)
 function ip4Header:setChecksum(int)
 	int = int or 0
 	self.cs = hton16(int)
 end
 
---- Calculate and set the IPv4 header checksum
--- If possible use checksum offloading (see pkt:offloadUdpChecksum) instead
+--- Calculate and set the checksum.
+-- If possible use checksum offloading instead.
+-- @see pkt:offloadUdpChecksum(ipv4, l2_len, l3_len)
 function ip4Header:calculateChecksum()
 	self:setChecksum() -- just to be sure (packet may be reused); must be 0 
-    self:setChecksum(checksum(self, 20))
+    self:setChecksum(hton16(checksum(self, 20)))
 end
 
+--- Set the destination address.
+-- @param int Address in 'union ipv4_address' format.
 function ip4Header:setDst(int)
 	self.dst:set(int)
 end
 
+--- Set the source address.
+-- @param int Address in 'union ipv4_address' format.
 function ip4Header:setSrc(int)
 	self.src:set(int)
 end
 
+--- Set the destination address.
+-- @param str Address in string format.
 function ip4Header:setDstString(str)
 	self:setDst(parseIP4Address(str))
 end
 
+--- Set the source address.
+-- @param str Address in string format.
 function ip4Header:setSrcString(str)
 	self:setSrc(parseIP4Address(str))
 end
 
+--- Set all members of the ip header.
+-- Per default, all members are set to default values specified in the respective set function.
+-- Optional named arguments can be used to set a member to a user-provided value.
+-- @param args Table of named arguments. Available arguments: ipVersion, ipHeaderLength, ipTOS, ipLength, ipID, ipFragment, ipTTL, ipProtocol, ipChecksum, ipSrc, ipDst
+-- @usage fill() -- only default values
+-- @usage fill{ ipSrc="1.1.1.1", ipTTL=100 } -- all members are set to default values with the exception of ipSrc and ipTTL
 function ip4Header:fill(args)
 	self:setVersion(args.ipVersion)
 	self:setHeaderLength(args.ipHeaderLength)
@@ -265,44 +308,44 @@ local ip4Addr = {}
 ip4Addr.__index = ip4Addr
 local ip4AddrType = ffi.typeof("union ipv4_address")
 
---- Retrieve the IPv4 address
--- @return address in uint32 format
+--- Retrieve the IPv4 address.
+-- @return Address in uint32 format.
 function ip4Addr:get()
 	return bswap(self.uint32)
 end
 
---- Set the IPv4 address
--- @param ip address in uint32 format
+--- Set the IPv4 address.
+-- @param ip Address in uint32 format.
 function ip4Addr:set(ip)
 	self.uint32 = bswap(ip)
 end
 
---- Set the IPv4 address
--- @param ip address in string format
+--- Set the IPv4 address.
+-- @param ip Address in string format.
 function ip4Addr:setString(ip)
 	self:set(parseIPAddress(ip))
 end
 
--- Retrieve the string representation of an IPv4 address
--- @return address in string format
+--- Retrieve the string representation of the IPv4 address.
+-- @return Address in string format.
 function ip4Addr:getString()
 	return ("%d.%d.%d.%d"):format(self.uint8[0], self.uint8[1], self.uint8[2], self.uint8[3])
 end
 
 
---- Test equality of two IPv4 addresses
--- @param lhs address in ipv4_address format
--- @param rhs address in ipv4_address format
--- @return is equal
+--- Test equality of two IPv4 addresses.
+-- @param lhs Address in 'union ipv4_address' format.
+-- @param rhs Address in 'union ipv4_address' format.
+-- @return true if equal, false otherwise.
 function ip4Addr.__eq(lhs, rhs)
 	return istype(ip4AddrType, lhs) and istype(ip4AddrType, rhs) and lhs.uint32 == rhs.uint32
 end 
 
---- Add a number to an IPv4 address
--- max. 32 bit, commutative
--- @param lhs address in ipv4_address format
--- @param rhs number to add
--- @return resulting address in uint32 format
+--- Add a number to an IPv4 address.
+-- Max. 32 bit, commutative.
+-- @param lhs Address in 'union ipv4_address' format.
+-- @param rhs Number to add (32 bit integer).
+-- @return Resulting address in uint32 format.
 function ip4Addr.__add(lhs, rhs)
 	-- calc ip (self) + number (val)
 	local self, val
@@ -318,16 +361,17 @@ function ip4Addr.__add(lhs, rhs)
 	return self.uint32 + val
 end
 
---- Add a number to an IPv4 address in-place, max 32 bit
--- @param val number to add
+--- Add a number to an IPv4 address in-place.
+-- Max. 32 bit.
+-- @param val Number to add (32 bit integer).
 function ip4Addr:add(val)
 	self.uint32 = self.uint32 + val
 end
 
---- Subtract a number from an IPv4 address
--- max. 32 bit
--- @param val number to substract
--- @return resulting address in uint32 format
+--- Subtract a number from an IPv4 address.
+-- Max. 32 bit.
+-- @param val Number to substract (32 bit integer)
+-- @return Resulting address in uint32 format.
 function ip4Addr:__sub(val)
 	return self + -val
 end
@@ -335,8 +379,8 @@ end
 --- ipv6 packets
 local udp6PacketType = ffi.typeof("struct udp_v6_packet*")
 
---- Retrieve an IPv6 UDP packet
--- @return the packet in udp_v6_packet format
+--- Retrieve an IPv6 UDP packet.
+-- @return Packet in 'struct udp_v6_packet' format.
 function pkt:getUDP6Packet()
 	return udp6PacketType(self.pkt.data)
 end
@@ -344,10 +388,8 @@ end
 local ip6Header = {}
 ip6Header.__index = ip6Header
 
--- TODO adjust default values
-
--- @param int ip header version, should always be '6' 
---		  4 bit integer
+--- Set the version. 
+-- @param int IP6 header version as 4 bit integer. Should always be '6'.
 function ip6Header:setVersion(int)
 	int = int or 6
 	int = band(lshift(int, 28), 0xf0000000) -- fill to 32 bits
@@ -358,8 +400,8 @@ function ip6Header:setVersion(int)
 	self.vtf = bswap(bor(old, int))
 end
 
--- @param int ip set traffic class of the ip header
---		  8 bit integer
+--- Set the traffic class.
+-- @param int Traffic class of the ip6 header as 8 bit integer.
 function ip6Header:setTrafficClass(int)
 	int = int or 0
 	int = band(lshift(int, 20), 0x0ff00000)
@@ -370,8 +412,8 @@ function ip6Header:setTrafficClass(int)
 	self.vtf = bswap(bor(old, int))
 end
 
--- @param int ip set flow label of the ip header
---		  20 bit integer
+--- Set the flow label.
+-- @param int Flow label of the ip6 header as 20 bit integer.
 function ip6Header:setFlowLabel(int)
 	int = int or 0
 	int = band(int, 0x000fffff)
@@ -382,37 +424,57 @@ function ip6Header:setFlowLabel(int)
 	self.vtf = bswap(bor(old, int))
 end
 
+--- Set the payload length.
+-- @param int Length of the ip6 header payload (hence, excluding l2 and l3 headers). 16 bit integer.
 function ip6Header:setLength(int)
 	int = int or 8	-- with eth + UDP -> minimum 66
 	self.len = hton16(int)
 end
 
+--- Set the next header.
+-- @param int Next header of the ip6 header as 8 bit integer.
 function ip6Header:setNextHeader(int)
 	int = int or 0x11	-- UDP
 	self.nextHeader = int
 end
 
+--- Set the time-to-live (TTL).
+-- @param int TTL of the ip6 header as 8 bit integer.
 function ip6Header:setTTL(int)
 	int = int or 64
 	self.ttl = int
 end
 
+--- Set the destination address.
+-- @param addr Address in 'union ipv6_address' format.
 function ip6Header:setDst(addr)
 	self.dst:set(addr)
 end
 
+--- Set the source  address.
+-- @param addr Address in 'union ipv6_address' format.
 function ip6Header:setSrc(addr)
 	self.src:set(addr)
 end
 
+--- Set the destination address.
+-- @param str Address in string format.
 function ip6Header:setDstString(str)
 	self:setDst(parseIP6Address(str))
 end
 
+--- Set the source address.
+-- @param str Address in string format.
 function ip6Header:setSrcString(str)
 	self:setSrc(parseIP6Address(str))
 end
 
+--- Set all members of the ip6 header.
+-- Per default, all members are set to default values specified in the respective set function.
+-- Optional named arguments can be used to set a member to a user-provided value.
+-- @param args Table of named arguments. Available arguments: ip6Version, ip6TrafficClass, ip6FlowLabel, ip6Length, ip6NextHeader, ip6TTL, ip6Src, ip6Dst
+-- @usage fill() -- only default values
+-- @usage fill{ ip6Src="f880::ab", ip6TTL=101 } -- all members are set to default values with the exception of ip6Src and ip6TTL
 function ip6Header:fill(args)
 	self:setVersion(args.ip6Version)
 	self:setTrafficClass(args.ip6TrafficClass)
@@ -428,8 +490,8 @@ local ip6Addr = {}
 ip6Addr.__index = ip6Addr
 local ip6AddrType = ffi.typeof("union ipv6_address")
 
---- Retrieve the IPv6 address
--- @return address in ipv6_address format
+--- Retrieve the IPv6 address.
+-- @return Address in 'union ipv6_address' format.
 function ip6Addr:get()
 	local addr = ip6AddrType()
 	addr.uint32[0] = bswap(self.uint32[3])
@@ -439,8 +501,8 @@ function ip6Addr:get()
 	return addr
 end
 
---- Set the IPv6 address
--- @param addr address in ipv6_address format
+--- Set the IPv6 address.
+-- @param addr Address in 'union ipv6_address' format.
 function ip6Addr:set(addr)
 	self.uint32[0] = bswap(addr.uint32[3])
 	self.uint32[1] = bswap(addr.uint32[2])
@@ -448,25 +510,25 @@ function ip6Addr:set(addr)
 	self.uint32[3] = bswap(addr.uint32[0])
 end
 
---- Set the IPv6 address
--- @param ip address in string format
+--- Set the IPv6 address.
+-- @param ip Address in string format.
 function ip6Addr:setString(ip)
 	self:set(parseIP6Address(ip))
 end
 
---- Test equality of two IPv6 addresses
--- @param lhs address in ipv6_address format
--- @param rhs address in ipv6_address format
--- @return is equal
+--- Test equality of two IPv6 addresses.
+-- @param lhs Address in 'union ipv6_address' format.
+-- @param rhs Address in 'union ipv6_address' format.
+-- @return true if equal, false otherwise.
 function ip6Addr.__eq(lhs, rhs)
 	return istype(ip6AddrType, lhs) and istype(ip6AddrType, rhs) and lhs.uint64[0] == rhs.uint64[0] and lhs.uint64[1] == rhs.uint64[1]
 end
 
---- Add a number to an IPv6 address
--- max. 64bit, commutative
--- @param lhs address in ipv6_address format
--- @param rhs number to add
--- @return resulting address in ipv6_address format
+--- Add a number to an IPv6 address.
+-- Max. 64bit, commutative.
+-- @param lhs Address in 'union ipv6_address' format.
+-- @param rhs Number to add (64 bit integer).
+-- @return Resulting address in 'union ipv6_address' format.
 function ip6Addr.__add(lhs, rhs)
 	-- calc ip (self) + number (val)
 	local self, val
@@ -493,8 +555,9 @@ function ip6Addr.__add(lhs, rhs)
 	return addr
 end
 
---- Add a number to an IPv6 address in-place, max 64 bit
--- @param val number to add
+--- Add a number to an IPv6 address in-place.
+-- Max 64 bit.
+-- @param val Number to add (64 bit integer).
 function ip6Addr:add(val)
 	-- calc ip (self) + number (val)
 	local low, high = bswap(self.uint64[1]), bswap(self.uint64[0])
@@ -510,18 +573,18 @@ function ip6Addr:add(val)
 	self.uint64[0] = bswap(high)
 end
 
---- Subtract a number from an IPv6 address
--- max. 64 bit
--- @param val number to substract
--- @return resulting address in ipv6_address format
+--- Subtract a number from an IPv6 address.
+-- Max. 64 bit.
+-- @param val Number to substract (64 bit integer).
+-- @return Resulting address in 'union ipv6_address' format.
 function ip6Addr:__sub(val)
 	return self + -val
 end
 
 -- Retrieve the string representation of an IPv6 address.
--- Assumes ipv6_address is in network byteorder
--- @param doByteSwap change byteorder
--- @return address in string format
+-- Assumes 'union ipv6_address' is in network byteorder.
+-- @param doByteSwap Optional change the byteorder of the ip6 address before returning the string representation.
+-- @return Address in string format.
 function ip6Addr:getString(doByteSwap)
 	doByteSwap = doByteSwap or false
 	if doByteSwap then
@@ -540,26 +603,40 @@ end
 local udpHeader = {}
 udpHeader.__index = udpHeader
 
+--- Set the source port.
+-- @param int Source port of the udp header as 16 bit integer.
 function udpHeader:setSrcPort(int)
 	int = int or 1024
 	self.src = hton16(int)
 end
 
+--- Set the destination port.
+-- @param int Destination port of the udp header as 16 bit integer.
 function udpHeader:setDstPort(int)
 	int = int or 1025
 	self.dst = hton16(int)
 end
 
+--- Set the length.
+-- @param int Length of the udp header plus payload (excluding l2 and l3). 16 bit integer.
 function udpHeader:setLength(int)
 	int = int or 28 -- with ethernet + IPv4 header -> 64B
 	self.len = hton16(int)
 end
 
+--- Set the checksum.
+-- @param int Checksum of the udp header as 16 bit integer.
 function udpHeader:setChecksum(int)
 	int = int or 0
 	self.cs = hton16(int)
 end
 
+--- Set all members of the udp header.
+-- Per default, all members are set to default values specified in the respective set function.
+-- Optional named arguments can be used to set a member to a user-provided value.
+-- @param args Table of named arguments. Available arguments: udpSrc, udpDst, udpLength, udpChecksum
+-- @usage fill() -- only default values
+-- @usage fill{ udpSrc=44566, ip6Length=101 } -- all members are set to default values with the exception of udpSrc and udpLength
 function udpHeader:fill(args)
 	self:setSrcPort(args.udpSrc)
 	self:setDstPort(args.udpDst)
@@ -571,6 +648,17 @@ end
 local udpPacket = {}
 udpPacket.__index = udpPacket
 
+--- Set all members of all headers.
+-- Per default, all members are set to default values specified in the respective set function.
+-- Optional named arguments can be used to set a member to a user-provided value.
+-- The argument 'pktLength' can be used to automatically calculate and set [ip,udp]Length members of the headers.
+-- @param args Table of named arguments. For a list of available arguments see "See also"
+-- @usage fill() -- only default values
+-- @usage fill{ ethSrc="12:23:34:45:56:67", ipTTL=100, udpDst=2500 } -- all members are set to default values with the exception of ethSrc, ipTTL and udpDst
+-- @usage fill{ pktLength=64 } -- only default values, all length members are set to the respective values (ipLength, udpLength)
+-- @see etherHeader:fill()
+-- @see ip4Header:fill()
+-- @see udpHeader:fill()
 function udpPacket:fill(args)
 	-- calculate length values for all headers
 	if args.pktLength then
@@ -586,7 +674,10 @@ function udpPacket:fill(args)
 	self.udp:fill(args)
 end
 
---- Calculate and set the UDP header checksum for IPv4 packets
+--- Calculate and set the UDP header checksum for IPv4 packets.
+-- Not implemented as it is optional.
+-- If possible use checksum offloading instead.
+-- @see pkt:offloadUdpChecksum()
 function udpPacket:calculateUDPChecksum()
 	-- optional, so don't do it
 	self.udp:setChecksum()
@@ -595,6 +686,17 @@ end
 local udp6Packet = {}
 udp6Packet.__index = udp6Packet
 
+--- Set all members of all headers.
+-- Per default, all members are set to default values specified in the respective set function.
+-- Optional named arguments can be used to set a member to a user-provided value.
+-- The argument 'pktLength' can be used to automatically calculate and set [ip6,udp]Length members of the headers.
+-- @param args Table of named arguments. For a list of available arguments see "See also"
+-- @usage fill() -- only default values
+-- @usage fill{ ethSrc="12:23:34:45:56:67", ip6TTL=100, udpDst=2500 } -- all members are set to default values with the exception of ethSrc, ip6TTL and udpDst
+-- @usage fill{ pktLength=64 } -- only default values, all length members are set to the respective values (ip6Length, udpLength)
+-- @see etherHeader:fill()
+-- @see ip6Header:fill()
+-- @see udpHeader:fill()
 function udp6Packet:fill(args)
 	-- calculate length values for all headers
 	if args.pktLength then
@@ -612,7 +714,10 @@ function udp6Packet:fill(args)
 	self.udp:fill(args)
 end
 
---- Calculate and set the UDP header checksum for IPv6 packets
+--- Calculate and set the UDP header checksum for IPv6 packets.
+-- Not implemented (todo).
+-- If possible use checksum offloading instead.
+-- @see pkt:offloadUdpChecksum()
 function udp6Packet:calculateUDPChecksum()
 	-- TODO as it is mandatory for IPv6 UDP packets
 	self.udp:setChecksum()

--- a/test/proto/testIPHeader.lua
+++ b/test/proto/testIPHeader.lua
@@ -38,7 +38,11 @@ describe("IP header class", function()
 		raw.protocol = 0x34
 		set:setProtocol(0x34)
 		assert.are.same(raw.protocol, set.protocol)
-		
+
+		raw.cs = hton16(10)
+		set:setChecksum(10)
+		assert.are.same(raw.cs, set.cs)
+
 		raw.src:setString("192.168.1.1")
 		set:setSrcString("192.168.1.1")
 		assert.are.same(raw.src.uint32, set.src.uint32)

--- a/test/proto/testIPHeader.lua
+++ b/test/proto/testIPHeader.lua
@@ -4,7 +4,7 @@ describe("IP header class", function()
 	it("should set IPv4", function()
 		local raw = ffi.new("struct ipv4_header")
 		local set = ffi.new("struct ipv4_header")
-		
+
 		raw.verihl = 0x45
 		set:setVersion()
 		set:setHeaderLength()

--- a/test/proto/testUDPHeader.lua
+++ b/test/proto/testUDPHeader.lua
@@ -1,0 +1,27 @@
+describe("UDP class", function()
+	local pkt = require "packet"
+	local ffi = require "ffi"
+	it("should set", function()
+		local raw = ffi.new("struct udp_header")
+		local set = ffi.new("struct udp_header")
+		
+		raw.src = hton16(1117)
+		set:setSrcPort(1117)
+		assert.are.same(raw.src, set.src)
+		
+		raw.dst = hton16(2223)
+		set:setDstPort(2223)
+		assert.are.same(raw.dst, set.dst)
+		
+		raw.len = hton16(55)
+		set:setLength(55)
+		assert.are.same(raw.len, set.len)
+		
+		raw.cs = hton16(5000)
+		set:setChecksum(5000)
+		assert.are.same(raw.cs, set.cs)
+
+	end)
+
+end)
+


### PR DESCRIPTION
- UDP setter functions (including unittests)
- setChecksum for ip header (including unittest)
- Fill functions for all headers and complete UDP[4,6] packets: …
All members are set to default values.
Named arguments can be used to set user-selected members to user-specified values.
example: :fill() --all default
	 :fill{ ethSrc="12:34:56:78:9a:bc",ipTTL=101 } --all default, ethernet src and ip TTL specified

Using the argument pktLength all header members regarding the length of the packet are automatically calculated and set.

Example usage in l3-multi-destinations.lua

- Updated l3-multi-destinations to new API (old code kept as comment)
- LuaDoc conform documentation for all functions in packet.lua