### PR TITLE
More/new utility for packets/headers:

### DIFF
--- a/lua/include/ethernet.lua
+++ b/lua/include/ethernet.lua
@@ -1,0 +1,8 @@
+local eth = {}
+
+--- Ethernet constants
+eth.TYPE_IP = 0x0800
+eth.TYPE_ARP = 0x0806 -- not implemented
+eth.TYPE_IP6 = 0x86dd
+
+return eth

--- a/lua/include/headers.lua
+++ b/lua/include/headers.lua
@@ -47,26 +47,38 @@ ffi.cdef[[
 	};
 
 	struct __attribute__((__packed__)) udp_header {                                                             
-		uint16_t 	src;
-		uint16_t     	dst;
-		uint16_t     	len;
-		uint16_t     	cs;
+		uint16_t	src;
+		uint16_t	dst;
+		uint16_t	len;
+		uint16_t	cs;
+	};
+
+	struct __attribute__((__packed__)) ip_packet {
+		struct ethernet_header 	eth;
+		struct ipv4_header	ip;
+		uint8_t 		payload[];
+	};
+
+	struct __attribute__((__packed__)) ip_v6_packet {
+		struct ethernet_header 	eth;
+		struct ipv6_header 	ip;
+		uint8_t 		payload[];
 	};
 
 	struct __attribute__((__packed__)) udp_packet {
-		struct ethernet_header  eth;
+		struct ethernet_header 	eth;
 		struct ipv4_header 	ip;
 		struct udp_header 	udp;
 		uint8_t			payload[];
 	};
 
 	struct __attribute__((__packed__)) ethernet_packet {
-		struct ethernet_header  eth;
+		struct ethernet_header 	eth;
 		uint8_t			payload[];
 	};
 
 	struct __attribute__((__packed__)) udp_v6_packet {
-		struct ethernet_header  eth;
+		struct ethernet_header	eth;
 		struct ipv6_header 	ip;
 		struct udp_header 	udp;
 		uint8_t			payload[];

--- a/lua/include/ip.lua
+++ b/lua/include/ip.lua
@@ -1,0 +1,7 @@
+local ip = {}
+
+--- IPv4 constants
+ip.PROTO_TCP = 0x06 -- not implemented
+ip.PROTO_UDP = 0x11
+
+return ip

--- a/lua/include/ip6.lua
+++ b/lua/include/ip6.lua
@@ -1,0 +1,8 @@
+local ip6 = {}
+
+--- IP6 constants
+-- TODO nextHeader uses same constants as IP protocol -> use the values from ip.lua?
+ip6.PROTO_TCP = 0x06 -- not implemented
+ip6.PROTO_UDP = 0x11
+ 
+return ip6

--- a/lua/include/utils.lua
+++ b/lua/include/utils.lua
@@ -1,5 +1,7 @@
 
 local bor, band, bnot, rshift, lshift, bswap = bit.bor, bit.band, bit.bnot, bit.rshift, bit.lshift, bit.bswap
+local write = io.write
+local format = string.format
 
 function printf(str, ...)
 	return print(str:format(...))
@@ -157,4 +159,55 @@ function parseIP6Address(ip)
 	return addr
 end
 
+--- Retrieve the system time with microseconds accuracy.
+-- TODO use some C function to get microseconds.
+-- @return System time in hh:mm:ss.uuuuuu format.
+function getTimeMicros()
+	local t = time()
+	local h, m, s, u
+	s = math.floor(t)	-- round to seconds
+	u = t - s		-- micro seconds
+	m = math.floor(s / 60)	-- total minutes
+	s = s - m * 60		-- remaining seconds
+	h = math.floor(m / 60)	-- total hours
+	m = m - h * 60		-- remaining minutes
+	h = h % 24		-- hour of the day
+	s = s + u		-- seconds + micro seconds
+	return format("%02d:%02d:%02.6f ", h, m, s)
+end
+
+--- Print a string with a restricted length per line.
+-- TODO don't linebreak words in the middle
+-- @param str The string to be printed.
+-- @param len Length of each line
+function printLength(str, len)
+	local beg = 0
+	for i = len, str:len(), len do
+		printf(str:sub(beg, i))
+		beg = i + 1
+	end
+	printf(str:sub(beg, str:len()))
+end
+
+--- Print a hex dump of cdata.
+-- @param data The cdata to be dumped.
+-- @param bytes Number of bytes to dump.
+function dumpHex(data, bytes)
+	local data = ffi.cast("uint8_t*", data)
+	for i = 0, bytes - 1 do
+		if i % 16 == 0 then -- new line
+			write(format("  0x%04x:   ", i))
+		end
+
+		write(format("%02x", data[i]))
+		
+		if i % 2  == 1 then -- group 2 bytes
+			write(" ")
+		end
+		if i % 16 == 15 then -- end of 16 byte line
+			write("\n")
+		end
+	end
+	write("\n\n")
+end
 


### PR DESCRIPTION
- removed FCS from length calculations (has to be substracted in
  rolescripts)
- added ip and ip6 packets
- get/getString for all members of all headers
- packet dumps for all packet types: information of the headers gets displayed
  in TCPDUMP-like manner + hex dump of the packet. As the packet does
not know its own length the user has to provide it.
- packet dump on rte_pktmbuf tries to guess the packet by lookig at
  ethertype/proto/nextHeader/... and dumps accordingly. Length is read
from rte_pktmbuf.
- ip/ip6/ethernet.lua with constants for ethertype/protocol
- updated l3-multi-destinations rolescript

Example: buf:dump()
16:59:36.541262 ETH 90:e2:ba:2c:cb:02 > 90:e2:ba:35:b5:81 ty
pe 0x0800 (IP4) IP4 192.168.1.1 > 10.0.0.1 ver 4 ihl 5 tos 0
 len 48 id 0 flags 0 frag 0 ttl 64 proto 0x11 (UDP) cksum 0x
0000 UDP 1024 > 1025 len 28 cksum 0x0000
  0x0000:   90e2 ba35 b581 90e2 ba2c cb02 0800 4500
  0x0010:   0030 0000 0000 4011 0000 c0a8 0101 0a00
  0x0020:   0001 0400 0401 001c 0000 0000 0000 0000
  0x0030:   0000 0000 0000 0000 0000 0000 0000