### PR TITLE
Add support for run multiple threads for tcp traffic generation

### DIFF
--- a/examples/l3-tcp-syn-flood.lua
+++ b/examples/l3-tcp-syn-flood.lua
@@ -11,21 +11,24 @@ local packet	= require "packet"
 local ffi	= require "ffi"
 
 function master(...)
-	local txPort = tonumber((select(1, ...)))
+	local txPorts = tostring((select(1, ...)))
 	local minIP = select(2, ...)
 	local numIPs = tonumber((select(3, ...)))
 	local rate = tonumber(select(4, ...))
 	
-	if not txPort or not minIP or not numIPs or not rate then
-		printf("usage: txPort minIP numIPs rate")
+	if not txPorts or not minIP or not numIPs or not rate then
+		printf("usage: txPort1,txPort2 minIP numIPs rate")
 		return
 	end
 
-	local rxMempool = memory.createMemPool()
-	local txDev = device.config(txPort, rxMempool, 2, 2)
-	txDev:wait()
-	txDev:getTxQueue(0):setRate(rate)
-	dpdk.launchLua("loadSlave", txPort, 0, minIP, numIPs)
+        for currentTxPort in txPorts:gmatch("[0-9+]") do
+		currentTxPort = tonumber(currentTxPort) 
+		local rxMempool = memory.createMemPool()
+		local txDev = device.config(currentTxPort, rxMempool, 2, 2)
+		txDev:wait()
+		txDev:getTxQueue(0):setRate(rate)
+		dpdk.launchLua("loadSlave", currentTxPort, 0, minIP, numIPs)
+        end
 	dpdk.waitForSlaves()
 end
 


### PR DESCRIPTION
Hello, MoonGen team!

I have tried to saturate 40GE link with two servers with 2*10GE with MoonGen. With single core version I could not call two instances of MoonGen and I decided to add some hacks to enable multi processing to the l3-tcp-syn example code.

Now I could generate about 24mpps with two lcores:
/usr/src/MoonGen/build/MoonGen examples/l3-tcp-syn-flood.lua 0,1 10.0.0.1 16000000 100000

```bash
  1  [|                                                        1.0%]     
  5  [                                                         0.0%]
  2  [|||||||||||||||||||||||||||||||||||||||||||||||||||||||100.0%]     
  6  [                                                         0.0%]
  3  [|||||||||||||||||||||||||||||||||||||||||||||||||||||||100.0%]     
  7  [                                                         0.0%]
  4  [|                                                        0.5%]     
  8  [                                                         0.0%]
```

On receiving side:
```bash
We process: 24712308 pps
We process: 24713463 pps
We process: 24709785 pps
We process: 24717191 pps
We process: 24717806 pps
We process: 24711876 pps
```

Could you accept my pull request? 