### PR TITLE
Add support for whitelisted PCI IDs.

### DIFF
--- a/lua/dpdk-conf.lua
+++ b/lua/dpdk-conf.lua
@@ -1,19 +1,21 @@
 -- configuration for all DPDK command line parameters
 -- see DPDK documentation for more details
+-- The DPDK EAL Parameters documentation is located at http://dpdk.org/doc/guides/testpmd_app_ug/run_app.html
 -- MoonGen tries to choose reasonable defaults, so this config file can almost always be empty
+-- Attention when running MoonGen in a VM that also uses another 'virtio' NIC e.g. for internet access.
+-- In this case it is required to whitelist the PCI IDs used (one could probably also blacklist all others).
 DPDKConfig {
 	-- configure the cores to use, either as a bitmask or as a list
 	-- default: all cores
 	--cores = 0x0F, -- use the first 4 cores
 	--cores = {0, 1, 3, 4},
-	
 	-- the number of memory channels (defaults to auto-detect)
 	--memoryChannels = 2,
 
 	-- the configures requried to run multiple DPDK applications. Refer to
 	-- http://dpdk.org/doc/guides/prog_guide/multi_proc_support.html#running-multiple-independent-dpdk-applications
 	-- for more information.
-	
+
 	-- a string to be the prefix, corresponding to EAL argument "--file-prefix"
 	--fileprefix = "m1",
 
@@ -24,7 +26,10 @@ DPDKConfig {
 	-- Corresponding to ELA argument "--pci-blacklist"
 	-- pciblack = {"0000:81:00.3","0000:81:00.1"},
 
+	-- PCI white list to specify devices allocated to MoonGen.
+	-- Corresponding to ELA argument "--pci-whitelist" or "-w"
+	-- pciwhite = {"0000:81:00.3","0000:81:00.1"},
+
 	-- disable hugetlb, see DPDK documentation for more information
 	--noHugeTlbFs = true,
 }
-

--- a/lua/include/dpdk.lua
+++ b/lua/include/dpdk.lua
@@ -16,7 +16,7 @@ local log 		= require "log"
 mod.PKT_RX_VLAN_PKT			= bit.lshift(1ULL, 0)
 mod.PKT_RX_RSS_HASH			= bit.lshift(1ULL, 1)
 mod.PKT_RX_FDIR				= bit.lshift(1ULL, 2)
-mod.PKT_RX_L4_CKSUM_BAD		= bit.lshift(1ULL, 3) 
+mod.PKT_RX_L4_CKSUM_BAD		= bit.lshift(1ULL, 3)
 mod.PKT_RX_IP_CKSUM_BAD		= bit.lshift(1ULL, 4)
 mod.PKT_RX_EIP_CKSUM_BAD	= bit.lshift(0ULL, 0)
 mod.PKT_RX_OVERSIZE			= bit.lshift(0ULL, 0)
@@ -146,8 +146,20 @@ function mod.init(cfgfile, ...)
                 else
 			log:warn("Need a list for the PCI black list")
 			return
-		end 
+		end
 	end
+
+	if cfg.pciwhite then
+		if type(cfg.pciwhite) == "table" then
+			for i, v in ipairs(cfg.pciwhite) do
+				argv[#argv + 1] = "-w" .. v
+			end
+				else
+			log:warn("Need a list for the PCI white list")
+			return
+		end
+	end
+
 
 	if cfg.socketmem then
 		argv[#argv + 1] = "--socket-mem=" .. cfg.socketmem
@@ -164,7 +176,7 @@ end
 
 ffi.cdef[[
 	void launch_lua_core(int core, uint64_t task_id, char* userscript, char* args);
-	
+
 	void free(void* ptr);
 	uint64_t generate_task_id();
 	void store_result(uint64_t task_id, char* result);
@@ -239,7 +251,7 @@ end
 
 --- launches the lua file on the first free core
 function mod.launchLua(...)
-	checkCore() 
+	checkCore()
 	for i = 2, #cores do -- skip master
 		local core = cores[i]
 		local status = dpdkc.rte_eal_get_lcore_state(core)
@@ -345,4 +357,3 @@ function mod.disableBadSocketWarning()
 end
 
 return mod
-


### PR DESCRIPTION
Whitelisted PCI IDs are configured in MoonGen's configfile and passed over to DPDK on startup.

This is especially helpful when running MoonGen in a VM that also has other virtio NICs. Blacklisting all other NICs would be possible, but whitelisting is more straight forward, hence the user also has to bind NICs to the DPDK drivers explicitly during setup.