### PR TITLE
Ipfix pkt gen

### DIFF
--- a/examples/ipfix-generation.lua
+++ b/examples/ipfix-generation.lua
@@ -32,7 +32,7 @@ local SAMPLING_PKT_SPACE    = 9999                        -- Sampling Packet Spa
 local PROTO_ID              = { 6, 17 }                   -- Protocol Identifier
 local SRC_TRANS             = { 80, 100 }                 -- Source Transport Port
 local DST_TRANS             = { 180, 200 }                -- Destination Transport Port
-local IPV4_ADDR             = { 1207959553, 2432696319 }  -- Range: 72.0.0.1 - 144.255.255.255
+local IPV4_ADDR             = {parseIPAddress("72.0.0.1"), parseIPAddress("144.255.255.255")} -- Range of IPv4 Addresses
 
 local SEQUENCE_NUMBER = 0
 local TOTAL_MESSAGES  = 0

--- a/examples/ipfix-generation.lua
+++ b/examples/ipfix-generation.lua
@@ -1,0 +1,247 @@
+local dpdk    = require "dpdk"
+local memory  = require "memory"
+local device  = require "device"
+local ts      = require "timestamping"
+local filter  = require "filter"
+local stats   = require "stats"
+local ffi     = require "ffi"
+local headers = require "headers"
+local ipfix   = require "proto.ipfix"
+
+-- Experiment Constants
+local IP_SRC    = "192.168.0.1"
+local ETH_DST   = "90:e2:ba:1f:8d:44"
+local IP_DST    = "10.0.10.10"
+local PORT_SRC  = 1234
+local PORT_DST  = 4739                  -- IPFIX port
+local SEND_RATE = 5                     -- MBits/s
+local SEND_TIME = 6000                  -- 6 secs
+local BURST_TIME= 2000                  -- 2 secs
+local RECORDS_PER_PACKET = 1
+
+
+-- Moongen Constants
+local MAX_PKT_SIZE  = 512
+
+-- IPFIX Packet Constants
+local PREV_HEADERS_LENGTH   = 42                          -- In octets
+local OBSERVATION_DOMAIN    = 67108864                    -- Observation Domain
+local SELECTOR_ALGORITHM    = 1                           -- Systematic count-based Sampling
+local SAMPLING_PKT_INTERVAL = 1                           -- Sampling Packet Interval
+local SAMPLING_PKT_SPACE    = 9999                        -- Sampling Packet Space
+local PROTO_ID              = { 6, 17 }                   -- Protocol Identifier
+local SRC_TRANS             = { 80, 100 }                 -- Source Transport Port
+local DST_TRANS             = { 180, 200 }                -- Destination Transport Port
+local IPV4_ADDR             = { 1207959553, 2432696319 }  -- Range: 72.0.0.1 - 144.255.255.255
+
+local SEQUENCE_NUMBER = 0
+local TOTAL_MESSAGES  = 0
+local TOTAL_FLOWS     = 0
+
+local TMPL_SET =
+{
+  {id = 8,  length = 4, value = function() return math.random(IPV4_ADDR[1], IPV4_ADDR[2]) end},     -- sourceIPv4Address (ipv4Address)
+  {id = 12, length = 4, value = function() return math.random(IPV4_ADDR[1], IPV4_ADDR[2]) end},     -- destinationIPv4Address(ipv4Address)
+  {id = 4,  length = 1, value = function() return PROTO_ID[math.random(table.getn(PROTO_ID))] end}, -- protocolIdentifier (unsigned8)
+  {id = 7,  length = 2, value = function() return math.random(SRC_TRANS[1], SRC_TRANS[2]) end},     -- sourceTransportPort (unsigned16)
+  {id = 11, length = 2, value = function() return math.random(DST_TRANS[1], DST_TRANS[2]) end}      -- destinationTransportPort (unsigned16)
+}
+
+local OPTS_TMPL_SET =
+{
+  {id = 149, length = 4, value = function() return OBSERVATION_DOMAIN end},       -- observationDomainId (unsigned32)
+  {id = 304, length = 2, value = function() return SELECTOR_ALGORITHM end},       -- selectorAlgorithm (unsigned16)
+  {id = 305, length = 4, value = function() return SAMPLING_PKT_INTERVAL end},    -- samplingPacketInterval (unsigned32)
+  {id = 306, length = 4, value = function() return SAMPLING_PKT_SPACE end}        -- samplingPacketSpace (unsigned32)
+}
+
+--- Main function and entry point for each MoonGen's script. Its funcion is to configure queues
+--- and filters on the used NICs and then start one or more slave tasks. It also configures the
+--- rates at which the exporting process sends the packets.
+--- @param txPort NIC's port
+--- @param rate rate at which packets will be sent
+--- @param recordsPerPkt number of data records per packet
+--- @param burst if burst == 1, then generate bursty traffic
+function master(txPort, rate, recordsPerPkt, burst)
+  if not txPort then
+    return print("usage: txPort [rate [recordsPerPkt [burst]]]")
+  end
+
+  -- if rate is not provided then use a default value of 2.5 MBits/s
+  rate = rate or SEND_RATE
+  time = SEND_TIME
+
+  -- if recordsPerPkt is not provided then use a default value of 1 record per packet
+  recordsPerPkt = recordsPerPkt or RECORDS_PER_PACKET
+
+  -- double rate for bursty traffic
+  burstRate = rate * 2
+
+  local speed = 0
+
+  -- the minimum rate of the hardware rate control is 0.1% of the link rate, i.e. 10 mbit/s.
+  -- for lower rates we have to configure the link rate speed to a slower rate
+  -- i.e. rate = 1 mbit/s, link rate = 1 Gbit/s
+  if (rate < 10) then
+    speed = 1000
+  end
+
+  -- configure tx device
+  local txDev = device.config({port = txPort, rxQueues = 2, txQueues = 3, speed = speed})
+  txDev:getTxQueue(0):setRate(rate)
+
+  -- wait until the links are up
+  device.waitForLinks()
+
+  printf("Sending %f MBit/s IPFIX traffic to UDP port %d", rate, PORT_DST)
+
+  if burst == 1 then
+    -- start burst slave (rate manager)
+    dpdk.launchLua("ipfixBurstSlave", txDev:getTxQueue(0), rate, SEND_TIME, burstRate, BURST_TIME)
+  end
+
+  -- start ipfx slave (exporting process)
+  dpdk.launchLua("ipfixSlave", txDev:getTxQueue(0), recordsPerPkt, PORT_DST)
+
+  -- wait until all tasks are finished
+  dpdk.waitForSlaves()
+end
+
+--- Task that modifies the rates at which the exporting process sends packets
+--- to the collector process. This prove to be very useful during our testing
+--- as it enabled us to simulate a more real scenario in which rates are not constants.
+--- @param queue NIC's queue over which packets are sent
+--- @param rate normal rate at which packets will be sent
+--- @param time normal time lapse in which "normal" traffic is generated
+--- @param burstRate burst rate at which packets will be sent
+--- @param burstTime burst time lapse in which "normal" traffic is generated
+function ipfixBurstSlave(queue, rate, time, burstRate, burstTime)
+  -- wait for the ipfixSlave task to start
+  dpdk.sleepMillis(100)
+  while dpdk.running() do
+    -- set normal rate and wait before switch to burst rate
+    queue:setRate(rate)
+    dpdk.sleepMillis(time)
+
+    -- set burst rate and wait before switch to normal rate
+    queue:setRate(burstRate)
+    dpdk.sleepMillis(burstTime)
+  end
+end
+
+--- Generates and sends ipfix packets to the collector process.
+--- @param queue NIC's queue over which packets are sent
+--- @param recordsPerPkt number of data records per packet
+--- @param port Tx port
+function ipfixSlave(queue, recordsPerPkt, port)
+  local mem = memory.createMemPool(function(buf)
+    -- creates an ipfix packet with the following values
+    buf:getIpfixPacket():fill{
+      -- creates an ipfix packet with the following values
+      ethSrc = queue,
+      ethDst = ETH_DST,
+      ip4Src = IP_SRC,
+      ip4Dst = IP_DST,
+      udpSrc = PORT_SRC,
+      udpDst = port,
+      ipfixObservationDomain = OBSERVATION_DOMAIN
+    }
+    -- for values not set in here, MoonGen uses the default
+    -- values specified in lua/include/proto/ipfix.lua
+  end)
+
+  local txCtr = stats:newManualTxCounter("Port " .. port, "plain")
+
+  local bufs = mem:bufArray()
+  local isFirst = true
+  local tmplLength = ipfix:getRecordLength(TMPL_SET)
+  local optsTmplLength = ipfix:getRecordLength(OPTS_TMPL_SET)
+  local pktSize = 0
+
+  -- stats counters
+  local deltaTime = dpdk.getTime()
+  local deltaFlows = 0
+  local deltaPkts = 0
+  local deltaBytes = 0
+
+  -- creates histogram.csv file and writes its headers
+  local histFile = io.open("histogram.csv", "w+")
+  histFile:write("delta_time,delta_flows,delta_packets,delta_bytes\n")
+  histFile:flush()
+
+  while dpdk.running() do
+    -- allocate buffers from the mem pool and store them in this array
+    bufs:alloc(MAX_PKT_SIZE)
+
+    for _, buf in ipairs(bufs) do
+      local pkt = buf:getIpfixPacket()
+      local msgSize = 0
+
+      -- modify packet's fields
+      pkt.ipfix:setExportTime(os.time())
+      pkt.ipfix:setSeq(SEQUENCE_NUMBER)
+
+      if isFirst then -- Create template set only the first time
+        -- Create template set
+        local tmplSet = ipfix:createTmplSet(998, TMPL_SET)
+        msgSize = ipfix:copyTo(pkt.payload.uint8, 0, tmplSet)
+
+        -- Create data set
+        local dataSet = ipfix:createDataSet(998, TMPL_SET, tmplLength, 1)
+        msgSize = ipfix:copyTo(pkt.payload.uint8, msgSize, dataSet)
+        TOTAL_FLOWS = TOTAL_FLOWS + 1
+        SEQUENCE_NUMBER = SEQUENCE_NUMBER + 1
+
+        isFirst = false
+      else -- Create only data sets
+        local dataSet = ipfix:createDataSet(998, TMPL_SET, tmplLength, recordsPerPkt)
+        msgSize = ipfix:copyTo(pkt.payload.uint8, 0, dataSet)
+        TOTAL_FLOWS = TOTAL_FLOWS + recordsPerPkt
+        SEQUENCE_NUMBER = SEQUENCE_NUMBER + recordsPerPkt
+      end
+
+      -- packet's size is given by the sum of the IPFIX headers and  message length
+      -- plus previous headers length e.g. (eth, ip4, udp)
+      pktSize = msgSize + PREV_HEADERS_LENGTH + ipfix:getHeadersLength()
+      pkt:setLength(pktSize)
+      buf:setSize(pktSize)
+
+      -- update exportedMessageTotalCount value
+      TOTAL_MESSAGES = TOTAL_MESSAGES + 1
+    end
+    -- send packets
+    bufs:offloadUdpChecksums()
+    txCtr:updateWithSize(queue:send(bufs), pktSize)
+
+    -- update stats
+    local time = dpdk.getTime()
+    if time - deltaTime >= 1 then
+      deltaTime = time - deltaTime
+      deltaFlows = SEQUENCE_NUMBER - deltaFlows
+      deltaPkts = txCtr.total - deltaPkts
+      deltaBytes = txCtr.totalBytes - deltaBytes
+
+      -- write stats
+      histFile:write(("%s,%s,%s,%s\n"):format(deltaTime, deltaFlows, deltaPkts, deltaBytes))
+      histFile:flush()
+
+      deltaTime = time
+      deltaFlows = SEQUENCE_NUMBER
+      deltaPkts = txCtr.total
+      deltaBytes = txCtr.totalBytes
+    end
+  end
+
+  txCtr:finalize()
+
+  -- update stats
+  deltaTime = dpdk.getTime() - deltaTime
+  deltaFlows = SEQUENCE_NUMBER - deltaFlows
+  deltaPkts = txCtr.total - deltaPkts
+  deltaBytes = txCtr.totalBytes - deltaBytes
+
+  -- write stats
+  histFile:write(("%s,%s,%s,%s\n"):format(deltaTime, deltaFlows, deltaPkts, deltaBytes))
+  histFile:flush()
+  histFile:close()
+end

--- a/examples/ipfix-generation.lua
+++ b/examples/ipfix-generation.lua
@@ -1,58 +1,57 @@
-local dpdk    = require "dpdk"
-local memory  = require "memory"
-local device  = require "device"
-local ts      = require "timestamping"
-local filter  = require "filter"
-local stats   = require "stats"
-local ffi     = require "ffi"
-local headers = require "headers"
-local ipfix   = require "proto.ipfix"
+local dpdk	= require "dpdk"
+local memory	= require "memory"
+local device	= require "device"
+local ts	= require "timestamping"
+local filter	= require "filter"
+local stats	= require "stats"
+local ffi	= require "ffi"
+local headers	= require "headers"
+local ipfix	= require "proto.ipfix"
 
 -- Experiment Constants
-local IP_SRC    = "192.168.0.1"
-local ETH_DST   = "90:e2:ba:1f:8d:44"
-local IP_DST    = "10.0.10.10"
-local PORT_SRC  = 1234
-local PORT_DST  = 4739                  -- IPFIX port
-local SEND_RATE = 5                     -- MBits/s
-local SEND_TIME = 6000                  -- 6 secs
-local BURST_TIME= 2000                  -- 2 secs
-local RECORDS_PER_PACKET = 1
-
+local IP_SRC		= "192.168.0.1"
+local ETH_DST		= "90:e2:ba:1f:8d:44"
+local IP_DST		= "10.0.10.10"
+local PORT_SRC		= 1234
+local PORT_DST		= 4739	-- IPFIX port
+local SEND_RATE		= 5	-- MBits/s
+local SEND_TIME		= 6000	-- 6 secs
+local BURST_TIME	= 2000	-- 2 secs
+local RECORDS_PER_PACKET= 1
 
 -- Moongen Constants
 local MAX_PKT_SIZE  = 512
 
 -- IPFIX Packet Constants
-local PREV_HEADERS_LENGTH   = 42                          -- In octets
-local OBSERVATION_DOMAIN    = 67108864                    -- Observation Domain
-local SELECTOR_ALGORITHM    = 1                           -- Systematic count-based Sampling
-local SAMPLING_PKT_INTERVAL = 1                           -- Sampling Packet Interval
-local SAMPLING_PKT_SPACE    = 9999                        -- Sampling Packet Space
-local PROTO_ID              = { 6, 17 }                   -- Protocol Identifier
-local SRC_TRANS             = { 80, 100 }                 -- Source Transport Port
-local DST_TRANS             = { 180, 200 }                -- Destination Transport Port
-local IPV4_ADDR             = {parseIPAddress("72.0.0.1"), parseIPAddress("144.255.255.255")} -- Range of IPv4 Addresses
+local PREV_HEADERS_LENGTH	= 42			-- In octets
+local OBSERVATION_DOMAIN	= 67108864		-- Observation Domain
+local SELECTOR_ALGORITHM	= 1			-- Systematic count-based Sampling
+local SAMPLING_PKT_INTERVAL	= 1			-- Sampling Packet Interval
+local SAMPLING_PKT_SPACE	= 9999			-- Sampling Packet Space
+local PROTO_ID			= { 6, 17 }		-- Protocol Identifier
+local SRC_TRANS			= { 80, 100 }		-- Source Transport Port
+local DST_TRANS			= { 180, 200 }		-- Destination Transport Port
+local IPV4_ADDR			= {parseIPAddress("72.0.0.1"), parseIPAddress("144.255.255.255")} -- Range of IPv4 Addresses
 
-local SEQUENCE_NUMBER = 0
-local TOTAL_MESSAGES  = 0
-local TOTAL_FLOWS     = 0
+local SEQUENCE_NUMBER	= 0
+local TOTAL_MESSAGES	= 0
+local TOTAL_FLOWS	= 0
 
 local TMPL_SET =
 {
-  {id = 8,  length = 4, value = function() return math.random(IPV4_ADDR[1], IPV4_ADDR[2]) end},     -- sourceIPv4Address (ipv4Address)
-  {id = 12, length = 4, value = function() return math.random(IPV4_ADDR[1], IPV4_ADDR[2]) end},     -- destinationIPv4Address(ipv4Address)
-  {id = 4,  length = 1, value = function() return PROTO_ID[math.random(table.getn(PROTO_ID))] end}, -- protocolIdentifier (unsigned8)
-  {id = 7,  length = 2, value = function() return math.random(SRC_TRANS[1], SRC_TRANS[2]) end},     -- sourceTransportPort (unsigned16)
-  {id = 11, length = 2, value = function() return math.random(DST_TRANS[1], DST_TRANS[2]) end}      -- destinationTransportPort (unsigned16)
+	{id = 8,  length = 4, value = function() return math.random(IPV4_ADDR[1], IPV4_ADDR[2]) end},		-- sourceIPv4Address (ipv4Address)
+	{id = 12, length = 4, value = function() return math.random(IPV4_ADDR[1], IPV4_ADDR[2]) end},		-- destinationIPv4Address(ipv4Address)
+	{id = 4,  length = 1, value = function() return PROTO_ID[math.random(table.getn(PROTO_ID))] end},	-- protocolIdentifier (unsigned8)
+	{id = 7,  length = 2, value = function() return math.random(SRC_TRANS[1], SRC_TRANS[2]) end},		-- sourceTransportPort (unsigned16)
+	{id = 11, length = 2, value = function() return math.random(DST_TRANS[1], DST_TRANS[2]) end}		-- destinationTransportPort (unsigned16)
 }
 
 local OPTS_TMPL_SET =
 {
-  {id = 149, length = 4, value = function() return OBSERVATION_DOMAIN end},       -- observationDomainId (unsigned32)
-  {id = 304, length = 2, value = function() return SELECTOR_ALGORITHM end},       -- selectorAlgorithm (unsigned16)
-  {id = 305, length = 4, value = function() return SAMPLING_PKT_INTERVAL end},    -- samplingPacketInterval (unsigned32)
-  {id = 306, length = 4, value = function() return SAMPLING_PKT_SPACE end}        -- samplingPacketSpace (unsigned32)
+	{id = 149, length = 4, value = function() return OBSERVATION_DOMAIN end},	-- observationDomainId (unsigned32)
+	{id = 304, length = 2, value = function() return SELECTOR_ALGORITHM end},	-- selectorAlgorithm (unsigned16)
+	{id = 305, length = 4, value = function() return SAMPLING_PKT_INTERVAL end},	-- samplingPacketInterval (unsigned32)
+	{id = 306, length = 4, value = function() return SAMPLING_PKT_SPACE end}	-- samplingPacketSpace (unsigned32)
 }
 
 --- Main function and entry point for each MoonGen's script. Its funcion is to configure queues
@@ -63,48 +62,48 @@ local OPTS_TMPL_SET =
 --- @param recordsPerPkt number of data records per packet
 --- @param burst if burst == 1, then generate bursty traffic
 function master(txPort, rate, recordsPerPkt, burst)
-  if not txPort then
-    return print("usage: txPort [rate [recordsPerPkt [burst]]]")
-  end
+	if not txPort then
+		return print("usage: txPort [rate [recordsPerPkt [burst]]]")
+	end
 
-  -- if rate is not provided then use a default value of 2.5 MBits/s
-  rate = rate or SEND_RATE
-  time = SEND_TIME
+	-- if rate is not provided then use a default value of 2.5 MBits/s
+	rate = rate or SEND_RATE
+	time = SEND_TIME
 
-  -- if recordsPerPkt is not provided then use a default value of 1 record per packet
-  recordsPerPkt = recordsPerPkt or RECORDS_PER_PACKET
+	-- if recordsPerPkt is not provided then use a default value of 1 record per packet
+	recordsPerPkt = recordsPerPkt or RECORDS_PER_PACKET
 
-  -- double rate for bursty traffic
-  burstRate = rate * 2
+	-- double rate for bursty traffic
+	burstRate = rate * 2
 
-  local speed = 0
+	local speed = 0
 
-  -- the minimum rate of the hardware rate control is 0.1% of the link rate, i.e. 10 mbit/s.
-  -- for lower rates we have to configure the link rate speed to a slower rate
-  -- i.e. rate = 1 mbit/s, link rate = 1 Gbit/s
-  if (rate < 10) then
-    speed = 1000
-  end
+	-- the minimum rate of the hardware rate control is 0.1% of the link rate, i.e. 10 mbit/s.
+	-- for lower rates we have to configure the link rate speed to a slower rate
+	-- i.e. rate = 1 mbit/s, link rate = 1 Gbit/s
+	if (rate < 10) then
+		speed = 1000
+	end
 
-  -- configure tx device
-  local txDev = device.config({port = txPort, rxQueues = 2, txQueues = 3, speed = speed})
-  txDev:getTxQueue(0):setRate(rate)
+	-- configure tx device
+	local txDev = device.config({port = txPort, rxQueues = 2, txQueues = 3, speed = speed})
+	txDev:getTxQueue(0):setRate(rate)
 
-  -- wait until the links are up
-  device.waitForLinks()
+	-- wait until the links are up
+	device.waitForLinks()
 
-  printf("Sending %f MBit/s IPFIX traffic to UDP port %d", rate, PORT_DST)
+	printf("Sending %f MBit/s IPFIX traffic to UDP port %d", rate, PORT_DST)
 
-  if burst == 1 then
-    -- start burst slave (rate manager)
-    dpdk.launchLua("ipfixBurstSlave", txDev:getTxQueue(0), rate, SEND_TIME, burstRate, BURST_TIME)
-  end
+	if burst == 1 then
+		-- start burst slave (rate manager)
+		dpdk.launchLua("ipfixBurstSlave", txDev:getTxQueue(0), rate, SEND_TIME, burstRate, BURST_TIME)
+	end
 
-  -- start ipfx slave (exporting process)
-  dpdk.launchLua("ipfixSlave", txDev:getTxQueue(0), recordsPerPkt, PORT_DST)
+	-- start ipfx slave (exporting process)
+	dpdk.launchLua("ipfixSlave", txDev:getTxQueue(0), recordsPerPkt, PORT_DST)
 
-  -- wait until all tasks are finished
-  dpdk.waitForSlaves()
+	-- wait until all tasks are finished
+	dpdk.waitForSlaves()
 end
 
 --- Task that modifies the rates at which the exporting process sends packets
@@ -116,17 +115,17 @@ end
 --- @param burstRate burst rate at which packets will be sent
 --- @param burstTime burst time lapse in which "normal" traffic is generated
 function ipfixBurstSlave(queue, rate, time, burstRate, burstTime)
-  -- wait for the ipfixSlave task to start
-  dpdk.sleepMillis(100)
-  while dpdk.running() do
-    -- set normal rate and wait before switch to burst rate
-    queue:setRate(rate)
-    dpdk.sleepMillis(time)
+	-- wait for the ipfixSlave task to start
+	dpdk.sleepMillis(100)
+	while dpdk.running() do
+		-- set normal rate and wait before switch to burst rate
+		queue:setRate(rate)
+		dpdk.sleepMillis(time)
 
-    -- set burst rate and wait before switch to normal rate
-    queue:setRate(burstRate)
-    dpdk.sleepMillis(burstTime)
-  end
+		-- set burst rate and wait before switch to normal rate
+		queue:setRate(burstRate)
+		dpdk.sleepMillis(burstTime)
+	end
 end
 
 --- Generates and sends ipfix packets to the collector process.
@@ -134,114 +133,114 @@ end
 --- @param recordsPerPkt number of data records per packet
 --- @param port Tx port
 function ipfixSlave(queue, recordsPerPkt, port)
-  local mem = memory.createMemPool(function(buf)
-    -- creates an ipfix packet with the following values
-    buf:getIpfixPacket():fill{
-      -- creates an ipfix packet with the following values
-      ethSrc = queue,
-      ethDst = ETH_DST,
-      ip4Src = IP_SRC,
-      ip4Dst = IP_DST,
-      udpSrc = PORT_SRC,
-      udpDst = port,
-      ipfixObservationDomain = OBSERVATION_DOMAIN
-    }
-    -- for values not set in here, MoonGen uses the default
-    -- values specified in lua/include/proto/ipfix.lua
-  end)
+	local mem = memory.createMemPool(function(buf)
+		-- creates an ipfix packet with the following values
+		buf:getIpfixPacket():fill{
+			-- creates an ipfix packet with the following values
+			ethSrc = queue,
+			ethDst = ETH_DST,
+			ip4Src = IP_SRC,
+			ip4Dst = IP_DST,
+			udpSrc = PORT_SRC,
+			udpDst = port,
+			ipfixObservationDomain = OBSERVATION_DOMAIN
+		}
+		-- for values not set in here, MoonGen uses the default
+		-- values specified in lua/include/proto/ipfix.lua
+	end)
 
-  local txCtr = stats:newManualTxCounter("Port " .. port, "plain")
+	local txCtr = stats:newManualTxCounter("Port " .. port, "plain")
 
-  local bufs = mem:bufArray()
-  local isFirst = true
-  local tmplLength = ipfix:getRecordLength(TMPL_SET)
-  local optsTmplLength = ipfix:getRecordLength(OPTS_TMPL_SET)
-  local pktSize = 0
+	local bufs = mem:bufArray()
+	local isFirst = true
+	local tmplLength = ipfix:getRecordLength(TMPL_SET)
+	local optsTmplLength = ipfix:getRecordLength(OPTS_TMPL_SET)
+	local pktSize = 0
 
-  -- stats counters
-  local deltaTime = dpdk.getTime()
-  local deltaFlows = 0
-  local deltaPkts = 0
-  local deltaBytes = 0
+	-- stats counters
+	local deltaTime = dpdk.getTime()
+	local deltaFlows = 0
+	local deltaPkts = 0
+	local deltaBytes = 0
 
-  -- creates histogram.csv file and writes its headers
-  local histFile = io.open("histogram.csv", "w+")
-  histFile:write("delta_time,delta_flows,delta_packets,delta_bytes\n")
-  histFile:flush()
+	-- creates histogram.csv file and writes its headers
+	local histFile = io.open("histogram.csv", "w+")
+	histFile:write("delta_time,delta_flows,delta_packets,delta_bytes\n")
+	histFile:flush()
 
-  while dpdk.running() do
-    -- allocate buffers from the mem pool and store them in this array
-    bufs:alloc(MAX_PKT_SIZE)
+	while dpdk.running() do
+		-- allocate buffers from the mem pool and store them in this array
+		bufs:alloc(MAX_PKT_SIZE)
 
-    for _, buf in ipairs(bufs) do
-      local pkt = buf:getIpfixPacket()
-      local msgSize = 0
+		for _, buf in ipairs(bufs) do
+			local pkt = buf:getIpfixPacket()
+			local msgSize = 0
 
-      -- modify packet's fields
-      pkt.ipfix:setExportTime(os.time())
-      pkt.ipfix:setSeq(SEQUENCE_NUMBER)
+			-- modify packet's fields
+			pkt.ipfix:setExportTime(os.time())
+			pkt.ipfix:setSeq(SEQUENCE_NUMBER)
 
-      if isFirst then -- Create template set only the first time
-        -- Create template set
-        local tmplSet = ipfix:createTmplSet(998, TMPL_SET)
-        msgSize = ipfix:copyTo(pkt.payload.uint8, 0, tmplSet)
+			if isFirst then -- Create template set only the first time
+				-- Create template set
+				local tmplSet = ipfix:createTmplSet(998, TMPL_SET)
+				msgSize = ipfix:copyTo(pkt.payload.uint8, 0, tmplSet)
 
-        -- Create data set
-        local dataSet = ipfix:createDataSet(998, TMPL_SET, tmplLength, 1)
-        msgSize = ipfix:copyTo(pkt.payload.uint8, msgSize, dataSet)
-        TOTAL_FLOWS = TOTAL_FLOWS + 1
-        SEQUENCE_NUMBER = SEQUENCE_NUMBER + 1
+				-- Create data set
+				local dataSet = ipfix:createDataSet(998, TMPL_SET, tmplLength, 1)
+				msgSize = ipfix:copyTo(pkt.payload.uint8, msgSize, dataSet)
+				TOTAL_FLOWS = TOTAL_FLOWS + 1
+				SEQUENCE_NUMBER = SEQUENCE_NUMBER + 1
 
-        isFirst = false
-      else -- Create only data sets
-        local dataSet = ipfix:createDataSet(998, TMPL_SET, tmplLength, recordsPerPkt)
-        msgSize = ipfix:copyTo(pkt.payload.uint8, 0, dataSet)
-        TOTAL_FLOWS = TOTAL_FLOWS + recordsPerPkt
-        SEQUENCE_NUMBER = SEQUENCE_NUMBER + recordsPerPkt
-      end
+				isFirst = false
+			else -- Create only data sets
+				local dataSet = ipfix:createDataSet(998, TMPL_SET, tmplLength, recordsPerPkt)
+				msgSize = ipfix:copyTo(pkt.payload.uint8, 0, dataSet)
+				TOTAL_FLOWS = TOTAL_FLOWS + recordsPerPkt
+				SEQUENCE_NUMBER = SEQUENCE_NUMBER + recordsPerPkt
+			end
 
-      -- packet's size is given by the sum of the IPFIX headers and  message length
-      -- plus previous headers length e.g. (eth, ip4, udp)
-      pktSize = msgSize + PREV_HEADERS_LENGTH + ipfix:getHeadersLength()
-      pkt:setLength(pktSize)
-      buf:setSize(pktSize)
+			-- packet's size is given by the sum of the IPFIX headers and  message length
+			-- plus previous headers length e.g. (eth, ip4, udp)
+			pktSize = msgSize + PREV_HEADERS_LENGTH + ipfix:getHeadersLength()
+			pkt:setLength(pktSize)
+			buf:setSize(pktSize)
 
-      -- update exportedMessageTotalCount value
-      TOTAL_MESSAGES = TOTAL_MESSAGES + 1
-    end
-    -- send packets
-    bufs:offloadUdpChecksums()
-    txCtr:updateWithSize(queue:send(bufs), pktSize)
+			-- update exportedMessageTotalCount value
+			TOTAL_MESSAGES = TOTAL_MESSAGES + 1
+		end
+		-- send packets
+		bufs:offloadUdpChecksums()
+		txCtr:updateWithSize(queue:send(bufs), pktSize)
 
-    -- update stats
-    local time = dpdk.getTime()
-    if time - deltaTime >= 1 then
-      deltaTime = time - deltaTime
-      deltaFlows = SEQUENCE_NUMBER - deltaFlows
-      deltaPkts = txCtr.total - deltaPkts
-      deltaBytes = txCtr.totalBytes - deltaBytes
+		-- update stats
+		local time = dpdk.getTime()
+		if time - deltaTime >= 1 then
+			deltaTime = time - deltaTime
+			deltaFlows = SEQUENCE_NUMBER - deltaFlows
+			deltaPkts = txCtr.total - deltaPkts
+			deltaBytes = txCtr.totalBytes - deltaBytes
 
-      -- write stats
-      histFile:write(("%s,%s,%s,%s\n"):format(deltaTime, deltaFlows, deltaPkts, deltaBytes))
-      histFile:flush()
+			-- write stats
+			histFile:write(("%s,%s,%s,%s\n"):format(deltaTime, deltaFlows, deltaPkts, deltaBytes))
+			histFile:flush()
 
-      deltaTime = time
-      deltaFlows = SEQUENCE_NUMBER
-      deltaPkts = txCtr.total
-      deltaBytes = txCtr.totalBytes
-    end
-  end
+			deltaTime = time
+			deltaFlows = SEQUENCE_NUMBER
+			deltaPkts = txCtr.total
+			deltaBytes = txCtr.totalBytes
+		end
+	end
 
-  txCtr:finalize()
+	txCtr:finalize()
 
-  -- update stats
-  deltaTime = dpdk.getTime() - deltaTime
-  deltaFlows = SEQUENCE_NUMBER - deltaFlows
-  deltaPkts = txCtr.total - deltaPkts
-  deltaBytes = txCtr.totalBytes - deltaBytes
+	-- update stats
+	deltaTime = dpdk.getTime() - deltaTime
+	deltaFlows = SEQUENCE_NUMBER - deltaFlows
+	deltaPkts = txCtr.total - deltaPkts
+	deltaBytes = txCtr.totalBytes - deltaBytes
 
-  -- write stats
-  histFile:write(("%s,%s,%s,%s\n"):format(deltaTime, deltaFlows, deltaPkts, deltaBytes))
-  histFile:flush()
-  histFile:close()
+	-- write stats
+	histFile:write(("%s,%s,%s,%s\n"):format(deltaTime, deltaFlows, deltaPkts, deltaBytes))
+	histFile:flush()
+	histFile:close()
 end

--- a/lua/include/headers.lua
+++ b/lua/include/headers.lua
@@ -169,6 +169,71 @@ ffi.cdef[[
 		uint16_t	arcount;
 		uint8_t		body[];
 	};
+
+	// -----------------------------------------------------
+	// ---- https://tools.ietf.org/html/rfc7011
+	// ---- IPFIX structures
+	// -----------------------------------------------------
+
+	struct __attribute__((__packed__)) ipfix_header {
+		uint16_t	version;
+		uint16_t	length;
+		uint32_t	export_time;
+		uint32_t	sequence_number;
+		uint32_t	observation_domain_id;
+	};
+
+	struct __attribute__((__packed__)) ipfix_set_header {
+		uint16_t	set_id;
+		uint16_t	length;
+	};
+
+	struct __attribute__((__packed__)) ipfix_tmpl_record_header {
+		uint16_t	template_id;
+		uint16_t	field_count;
+	};
+
+	struct __attribute__((__packed__)) ipfix_opts_tmpl_record_header {
+		uint16_t	template_id;
+		uint16_t	field_count;
+		uint16_t	scope_field_count;
+	};
+
+	struct __attribute__((__packed__)) ipfix_information_element {
+		uint16_t	ie_id;
+		uint16_t	length;
+	};
+
+	struct __attribute__((__packed__)) ipfix_data_record {
+		uint8_t		field_values[?];
+	};
+
+	struct __attribute__((__packed__)) ipfix_tmpl_record {
+		struct ipfix_tmpl_record_header		template_header;
+		struct ipfix_information_element	information_elements[5];
+	};
+
+	struct __attribute__((__packed__)) ipfix_opts_tmpl_record {
+		struct ipfix_opts_tmpl_record_header	template_header;
+		struct ipfix_information_element	information_elements[5];
+	};
+
+	struct __attribute__((__packet__)) ipfix_data_set {
+		struct ipfix_set_header		set_header;
+		uint8_t				field_values[?];
+	};
+
+	struct __attribute__((__packet__)) ipfix_tmpl_set {
+		struct ipfix_set_header		set_header;
+		struct ipfix_tmpl_record	record;
+		uint8_t				padding;
+	};
+
+	struct __attribute__((__packet__)) ipfix_opts_tmpl_set {
+		struct ipfix_set_header		set_header;
+		struct ipfix_opts_tmpl_record	record;
+		uint8_t				padding;
+	};
 ]]
 
 return ffi.C

--- a/lua/include/packet.lua
+++ b/lua/include/packet.lua
@@ -538,7 +538,7 @@ function packetSetLength(args)
 	local accumulatedLength = 0
 	for _, v in ipairs(args) do
 		local header, member = getHeaderMember(v)
-		if header == "ip4" or header == "udp" or header == "ptp" then
+		if header == "ip4" or header == "udp" or header == "ptp" or header == "ipfix" then
 			str = str .. [[
 				self.]] .. member .. [[:setLength(length - ]] .. accumulatedLength .. [[)
 				]]

--- a/lua/include/proto/ipfix.lua
+++ b/lua/include/proto/ipfix.lua
@@ -1,0 +1,468 @@
+------------------------------------------------------------------------
+--- @file ipfix.lua
+--- @brief IPFIX packet generation.
+--- Utility functions for the ipfix_header structs
+--- defined in \ref headers.lua . \n
+--- Includes:
+--- - IPFIX constants
+--- - IPFIX header utility
+--- - Definition of IPFIX packets
+--- - Functions to create an IPFIX Message
+------------------------------------------------------------------------
+
+local ffi = require "ffi"
+local pkt = require "packet"
+
+require "utils"
+require "headers"
+
+local ntoh, hton = ntoh, hton
+local ntoh16, hton16 = ntoh16, hton16
+local bswap = bswap
+local bswap16 = bswap16
+local bor, band, bnot, rshift, lshift= bit.bor, bit.band, bit.bnot, bit.rshift, bit.lshift
+
+---------------------------------------------------------------------------
+---- IPFIX constants
+---------------------------------------------------------------------------
+
+--- IPFIX protocol constants
+local ipfix = {}
+
+-- NetFlow v5
+ipfix.VERSION_NFV5 = 0x0005
+-- NetFlow v9
+ipfix.VERSION_NFV9 = 0x0009
+-- IPFIX
+ipfix.VERSION_IPFIX = 0x000a
+
+-- Set ID for template set
+ipfix.ID_TEMPLATE_SET = 0x0002
+-- Set ID for option template set
+ipfix.ID_OPTION_TEMPLATE_SET = 0x0003
+-- Minimum data set ID
+ipfix.ID_MIN_DATA_SET = 0x00ff
+-- Enterprise bit
+ipfix.ENTERPRISE_BIT = 0x00
+
+
+---------------------------------------------------------------------------
+---- IPFix header
+---- https://tools.ietf.org/html/rfc7011#section-3.1
+---------------------------------------------------------------------------
+
+--- Module for ipfix struct (see \ref headers.lua).
+local ipfixHeader = {}
+ipfixHeader.__index = ipfixHeader
+
+--- Set the version.
+--- @param int version of the ipfix header as a 16 bits integer.
+function ipfixHeader:setVersion(int)
+	int = int or ipfix.VERSION_IPFIX
+	self.version = hton16(int)
+end
+
+--- Retrieve the version.
+--- @return version as a 16 bits integer.
+function ipfixHeader:getVersion()
+	return hton16(self.version)
+end
+
+--- Retrieve the version as string.
+--- @return version as string.
+function ipfixHeader:getVersionString()
+	return self:getVersion()
+end
+
+--- Set the header length.
+--- @param int length of the ipfix header as a 16 bits integer.
+function ipfixHeader:setLength(int)
+	int = int or 0
+	self.length = hton16(int)
+end
+
+--- Retrieve the length.
+--- @return length as a 16 bits integer.
+function ipfixHeader:getLength()
+	return hton16(self.length)
+end
+
+--- Retrieve the length as string.
+--- @return length as string.
+function ipfixHeader:getLengthString()
+	return self:getLength()
+end
+
+--- Set the header export time.
+--- @param int export time of the ipfix header as a 32 bits integer.
+function ipfixHeader:setExportTime(int)
+	int = int or 0
+	self.export_time = bswap(int)
+end
+
+--- Retrieve the export time.
+--- @return export time as a 32 bits integer.
+function ipfixHeader:getExportTime()
+	return bswap(self.export_time)
+end
+
+--- Retrieve the export time as string.
+--- @return export time as string.
+function ipfixHeader:getExportTimeString()
+	return self:getExportTime()
+end
+
+--- Set the header seq.
+--- @param int seq of the ipfix header as a 32 bits integer.
+function ipfixHeader:setSeq(int)
+	int = int or 0
+	self.sequence_number = bswap(int)
+end
+
+--- Retrieve the seq.
+--- @return seq as a 32 bits integer.
+function ipfixHeader:getSeq()
+	return bswap(self.sequence_number)
+end
+
+--- Retrieve the seq as string.
+--- @return seq as string.
+function ipfixHeader:getSeqString()
+	return self:getSeq()
+end
+
+--- Set the header observation domain.
+--- @param int observation domain id of the ipfix header as a 32 bits integer.
+function ipfixHeader:setObservationDomain(int)
+	int = int or 0
+	self.observation_domain_id = bswap(int)
+end
+
+--- Retrieve the observation domain id.
+--- @return obsevation domain as a 32 bits integer.
+function ipfixHeader:getObservationDomain()
+	return bswap(self.observation_domain_id)
+end
+
+--- Retrieve the observation domain as string.
+--- @return observation domain as string.
+function ipfixHeader:getObservationDomainString()
+	return self:getObservationDomain()
+end
+
+
+--- Set all members of the ipfix header.
+--- Per default, all members are set to default values specified in the respective set function.
+--- Optional named arguments can be used to set a member to a user-provided value.
+--- @param args Table of named arguments. Available arguments: ipfixXYZ
+--- @param pre prefix for namedArgs. Default 'ipfix'.
+--- @code
+--- fill() -- only default values
+--- fill{ ipfixXYZ=1 } -- all members are set to default values with the exception of ipfixXYZ, ...
+--- @endcode
+function ipfixHeader:fill(args, pre)
+	args = args or {}
+	pre = pre or "ipfix"
+
+	self:setVersion			(args[pre .. "Version"])
+	self:setLength			(args[pre .. "Length"])
+	self:setExportTime		(args[pre .. "ExportTime"])
+	self:setSeq			(args[pre .. "Seq"])
+	self:setObservationDomain	(args[pre .. "ObservationDomain"])
+end
+
+--- Retrieve the values of all members.
+--- @param pre prefix for namedArgs. Default 'ipfix'.
+--- @return Table of named arguments. For a list of arguments see "See also".
+--- @see ipfixHeader:fill
+function ipfixHeader:get(pre)
+	pre = pre or "ipfix"
+
+	local args = {}
+	args[pre .. "Version"]			= self:getVersion()
+	args[pre .. "Length"]			= self:getLength()
+	args[pre .. "ExportTime"]		= self:getExportTime()
+	args[pre .. "Seq"]			= self:getSeq()
+	args[pre .. "ObservationDomain"]	= self:getObservationDomain()
+
+	return args
+end
+
+--- Retrieve the values of all members.
+--- @return Values in string format.
+function ipfixHeader:getString()
+	return "ipfix > "
+		.. " version "			.. self:getVersionString()
+		.. " length "			.. self:getLengthString()
+		.. " export time "		.. self:getExportTimeString()
+		.. " sequence number "		.. self:getSeqString()
+		.. " observation domain id "	.. self:getObservationDomainString()
+end
+
+--- Resolve which header comes after this one (in a packet)
+--- For instance: in tcp/udp based on the ports
+--- This function must exist and is only used when get/dump is executed on
+--- an unknown (mbuf not yet casted to e.g. tcpv6 packet) packet (mbuf)
+--- @return String next header (e.g. 'eth', 'ip4', nil)
+function ipfixHeader:resolveNextHeader()
+	return nil
+end	
+
+--- Change the default values for namedArguments (for fill/get)
+--- This can be used to for instance calculate a length value based on the total packet length
+--- See ipfix/ip4.setDefaultNamedArgs as an example
+--- This function must exist and is only used by packet.fill
+--- @param pre The prefix used for the namedArgs, e.g. 'ipfix'
+--- @param namedArgs Table of named arguments (see See more)
+--- @param nextHeader The header following after this header in a packet
+--- @param accumulatedLength The so far accumulated length for previous headers in a packet
+--- @see ipfixHeader:fill
+function ipfixHeader:setDefaultNamedArgs(pre, namedArgs, nextHeader, accumulatedLength)
+	if not namedArgs[pre .. "Length"] and namedArgs["pktLength"] then
+		namedArgs[pre .. "Length"] = namedArgs["pktLength"] - accumulatedLength
+	end
+
+	return namedArgs
+end
+
+
+----------------------------------------------------------------------------------
+---- Packets
+----------------------------------------------------------------------------------
+
+--[[ define how a packet with this header looks like
+-- e.g. 'ip4' will add a member ip4 of type struct ip4_header to the packet
+-- e.g. {'ip4', 'innerIP'} will add a member innerIP of type struct ip4_header to the packet
+--]]
+--- Cast the packet to a ipfix (IPFix) packet
+pkt.getIpfixPacket = packetCreate("eth", "ip4", "udp", "ipfix")
+
+
+----------------------------------------------------------------------------------
+---- IPFix Message
+----------------------------------------------------------------------------------
+
+--- Creates an Information Element
+--- @param id A numeric value that represents the Information Element
+--- @param length The length of the corresponding encoded Information Element, in octets
+--- @return a new Information Element
+function ipfix:createInformationElement(id, length)
+	local informationElement = InformationElement()
+	informationElement.ie_id = hton16(id)
+	informationElement.length = hton16(length)
+
+	return informationElement
+end
+
+--- Creates a Set Header
+--- @param id Set ID
+--- @param length Total length of the Set, in octets, including the Set Header, records,
+--- and the optional padding.
+--- @return a new Set Header
+function ipfix:createSetHeader(id, length)
+	local setHeader = SetHeader()
+	setHeader.set_id = hton16(id)
+	setHeader.length = hton16(length)
+
+	return setHeader
+end
+
+--- Creates a Template Record Header
+--- @param id Template Id
+--- @param fieldCount Number of fields in this Template Record
+--- @return a new Template Record Header
+function ipfix:createTmplRecordHeader(id, fieldCount)
+	local tmplRecordHeader = TmplRecordHeader()
+	tmplRecordHeader.template_id = hton16(id)
+	tmplRecordHeader.field_count = hton16(fieldCount)
+
+	return tmplRecordHeader
+end
+
+--- Creates an Options Template Record Header
+--- @param id Options Template Id
+--- @param fieldCount Number of fields in this Options Template Record
+--- @param scopeFieldCount Number of scope fields in this Options Template Record
+--- @return a new Options Template Record Header
+function ipfix:createOptsTmplRecordHeader(id, fieldCount, scopeFieldCount)
+	local optsTmplRecordHeader = OptsTmplRecordHeader()
+	optsTmplRecordHeader.template_id = hton16(id)
+	optsTmplRecordHeader.field_count = hton16(fieldCount)
+	optsTmplRecordHeader.scope_field_count = hton16(scopeFieldCount)
+
+	return optsTmplRecordHeader
+end
+
+--- Creates a Template Set with the Information Elements described in 'template'
+--- @param id Template Set Id
+--- @param template Contains the Information Elements for this Template Set, e.g.
+--- @code
+--- local template ={
+--- {id = 8,  length = 4, value = function() return math.random(1207959553, 2432696319) end},
+--- {id = 12, length = 4, value = function() return math.random(1207959553, 2432696319) end},
+--- {id = 4,  length = 1, value = function() return 17 end},
+--- {id = 7,  length = 2, value = function() return math.random(80, 100 end},
+--- {id = 11, length = 2, value = function() return math.random(180, 200) end}
+--- }
+--- @endcode
+--- id and length are defined in:
+--- http://www.iana.org/assignments/ipfix/ipfix.xhtml#ipfix-information-elements
+--- value is a function to calculate or return the the value to be used when creating a Data Record
+--- @return a new Template Set
+function ipfix:createTmplSet(id, template)
+	local headerLength = ffi.sizeof(SetHeader)
+	local recordHeaderLength = ffi.sizeof(TmplRecordHeader)
+	local ieLength = ffi.sizeof(InformationElement)
+
+	local set = TmplSet()
+	local numOfFields = table.getn(template)
+	local tmplSetLength = headerLength + recordHeaderLength + (ieLength * numOfFields)
+
+	local header = self:createSetHeader(self.ID_TEMPLATE_SET, tmplSetLength)
+	local record = TmplRecord()
+	local recordHeader = self:createTmplRecordHeader(id, numOfFields)
+
+	for i, ie in ipairs(template) do
+		record.information_elements[i-1] = self:createInformationElement(ie.id, ie.length)
+	end
+
+	record.template_header = recordHeader
+	set.set_header = header
+	set.record = record
+
+	return set
+end
+
+
+--- Creates an Options Template Set with the Information Elements described in 'opts_template'
+--- @param id Options Template Set Id
+--- @param opts_template Contains the Information Elements for this Options Template Set, e.g.
+--- @code
+--- local opts_template ={
+--- {id = 8,  length = 4, value = function() return math.random(1207959553, 2432696319) end},
+--- {id = 12, length = 4, value = function() return math.random(1207959553, 2432696319) end},
+--- {id = 4,  length = 1, value = function() return 17 end},
+--- {id = 7,  length = 2, value = function() return math.random(80, 100 end},
+--- {id = 11, length = 2, value = function() return math.random(180, 200) end}
+--- }
+--- @endcode
+--- id and length are defined in:
+--- http://www.iana.org/assignments/ipfix/ipfix.xhtml#ipfix-information-elements
+--- value is a function to calculate or return the the value to be used when creating a Data Record
+--- @return a new Options Template Set
+function ipfix:createOptsTmplSet(id, opts_template)
+	local headerLength = ffi.sizeof(SetHeader)
+	local recordHeaderLength = ffi.sizeof(OptsTmplRecordHeader)
+	local ieLength = ffi.sizeof(InformationElement)
+
+	local set = OptsTmplSet()
+	local numOfFields = table.getn(opts_template)
+	-- Add 2 more octets which correspond to the padding field
+	local optsTmplSetLength = headerLength + recordHeaderLength + 2 + (ieLength * numOfFields)
+
+	local header = self:createSetHeader(self.ID_OPTION_TEMPLATE_SET, optsTmplSetLength)
+	local record = OptsTmplRecord()
+	local recordHeader = self:createOptsTmplRecordHeader(id, numOfFields, 1)
+
+	for i, ie in ipairs(opts_template) do
+		record.information_elements[i-1] = self:createInformationElement(ie.id, ie.length)
+	end
+
+	record.template_header = recordHeader
+	set.set_header = header
+	set.record = record
+	set.padding = hton16(0)
+
+	return set
+end
+
+--- Calculates the length, in octets, of a Data Record based on its template
+--- @param template Contains the Information Elements for this Flow Record
+--- @return Flow Record's length, in octets
+function ipfix:getRecordLength(template)
+	local length = 0
+
+	for _, ie in ipairs(template) do
+		length = length + ie.length
+	end
+
+	return length
+end
+
+--- Creates a Data Set the Information Elements described in 'template'
+--- @param id Template Id
+--- @param template Contains the Information Elements for this Data Set
+--- @param recordLength Length in octets for each Data Record
+--- @param numOfRecords Number of Data Records within this Set
+--- @return a new Data Set containing numOfRecords Data Records
+function ipfix:createDataSet(id, template, recordLength, numOfRecords)
+	local headerLength = ffi.sizeof(SetHeader)
+
+	local header = self:createSetHeader(id, headerLength + (numOfRecords * recordLength))
+
+	local set = DataSet(numOfRecords * recordLength)
+	local index = 0
+
+	for i = 1, numOfRecords do
+		for _, ie in ipairs(template) do
+			local offset = ie.length - 1
+
+			while offset >= 0 do
+				set.field_values[index] = bit.rshift(ie.value(), offset * 8)
+				index = index + 1
+				offset = offset - 1
+			end
+		end
+	end
+
+	set.set_header = header
+
+	return set
+end
+
+--- Copies Set into destination
+--- @param dest Destination for the set
+--- @param pos Start position for this set in dest
+--- @param set Set
+--- @return End position for this set in destination
+function ipfix:copyTo(dest, pos, set)
+	local length = ntoh16(set.set_header.length)
+	local s = ffi.string(set, length)
+	local aux = 1
+
+	length = length + pos
+
+	while pos < length do
+		dest[pos] = s:byte(aux)
+		pos = pos + 1
+		aux = aux + 1
+	end
+
+	return pos
+end
+
+--- Returns Header's length in octets
+function ipfix:getHeadersLength()
+	return ffi.sizeof(Header)
+end
+
+
+------------------------------------------------------------------------
+---- Metatypes
+------------------------------------------------------------------------
+
+ffi.metatype("struct ipfix_header", ipfixHeader)
+
+-- ctypes
+Header                = ffi.typeof("struct ipfix_header")
+SetHeader             = ffi.typeof("struct ipfix_set_header")
+InformationElement    = ffi.typeof("struct ipfix_information_element")
+DataSet               = ffi.typeof("struct ipfix_data_set")
+TmplSet               = ffi.typeof("struct ipfix_tmpl_set")
+TmplRecord            = ffi.typeof("struct ipfix_tmpl_record")
+TmplRecordHeader      = ffi.typeof("struct ipfix_tmpl_record_header")
+OptsTmplSet           = ffi.typeof("struct ipfix_opts_tmpl_set")
+OptsTmplRecord        = ffi.typeof("struct ipfix_opts_tmpl_record")
+OptsTmplRecordHeader  = ffi.typeof("struct ipfix_opts_tmpl_record_header")
+
+return ipfix

--- a/lua/include/proto/proto.lua
+++ b/lua/include/proto/proto.lua
@@ -16,5 +16,6 @@ proto.vxlan = require "proto.vxlan"
 proto.esp = require "proto.esp"
 proto.ah = require "proto.ah"
 proto.dns = require "proto.dns"
+proto.ipfix = require "proto.ipfix"
 
 return proto


### PR DESCRIPTION
Add script to generate and send IPFIX Messages.
It can simulate bursty traffic by using the double
of the specified rate speed. Additionally, it can
transmit at rate speeds below 10 Mbit/s. A CSV
report is generated with the number of packets,
flows and time.