### PR TITLE
RecoreSystems: Add arbitrary time software rate control and update rate-control and replay-pcap examples

### DIFF
--- a/examples/pcap/replay-pcap.lua
+++ b/examples/pcap/replay-pcap.lua
@@ -6,41 +6,65 @@ local memory = require "memory"
 local stats  = require "stats"
 local log    = require "log"
 local pcap   = require "pcap"
+local limiter = require "software-ratecontrol"
 
 function configure(parser)
 	parser:argument("dev", "Device to use."):args(1):convert(tonumber)
-	parser:argument("file", "File to replay."):args(1)
-	parser:option("-r --rate-multiplier", "Speed up or slow down replay, 1 = use intervals from file, default = replay as fast as possible"):default(0):convert(tonumber):target("rateMultiplier")
-	parser:flag("-l --loop", "Repeat pcap file.")
-	local args = parser:parse()
-	if args.rateMultiplier ~= 0 then
-		parser:error("rate control is NYI")
-	end
-	return args
+    parser:argument("file", "File to replay."):args(1)
+    parser:option("-r --rate-multiplier", "Speed up or slow down replay, 1 = use intervals from file, default = replay as fast as possible"):default(0):convert(tonumber):target("rateMultiplier")
+    parser:flag("-l --loop", "Repeat pcap file.")
+    local args = parser:parse()
+    return args
 end
 
 function master(args)
 	local dev = device.config{port = args.dev}
-	device.waitForLinks()
-	mg.startTask("replay", dev:getTxQueue(0), args.file, args.loop)
-	stats.startStatsTask{txDevices = {dev}}
-	mg.waitForTasks()
+    device.waitForLinks()
+    rateLimiter = nil
+    if args.rateMultiplier == 1 then
+        rateLimiter = limiter:new(dev:getTxQueue(0), "custom")
+    end
+    mg.startTask("replay", dev:getTxQueue(0), args.file, args.loop, rateLimiter)
+    stats.startStatsTask{txDevices = {dev}}
+    mg.waitForTasks()
 end
 
-function replay(queue, file, loop)
+function replay(queue, file, loop, rateLimiter)
 	local mempool = memory:createMemPool()
-	local bufs = mempool:bufArray()
-	local pcapFile = pcap:newReader(file)
-	while mg.running() do
-		local n = pcapFile:read(bufs)
-		if n == 0 then
-			if loop then
-				pcapFile:reset()
-			else
-				break
-			end
-		end
-		queue:sendN(bufs, n)
-	end
+    local bufs = mempool:bufArray()
+    -- software-ratecontrol.lua#L29 For now it's mandatory to use a buffer of 1 position (lower or equal to the #packets in the pcap file)
+    if rateLimiter ~= nil then
+        bufs = mempool:bufArray(1)
+    end
+    local pcapFile = pcap:newReader(file)
+    local prev = 0;
+    while mg.running() do
+        local n = pcapFile:read(bufs)
+        if n > 0 then
+            if rateLimiter ~= nil then
+                if prev == 0 then
+                    prev = (bufs.array[0].udata64 % 1000000) * 1000000 + math.floor(tonumber(bufs.array[0].udata64) / 1000000)
+                end
+                -- using pcap don't use ipairs (ipairs starts in 1 and C code in 0 - this produce index fails)
+                for i=0, n-1 do
+                    local cur = (bufs.array[i].udata64 % 1000000) * 1000000 + math.floor(tonumber(bufs.array[i].udata64) / 1000000)
+                    bufs.array[i]:setDelay((cur-prev) * queue.dev:getLinkStatus().speed / 8)
+                    prev = cur
+                end
+            end
+        else
+        	if loop then
+            	pcapFile:reset()
+        	else
+            	break
+        	end
+    	end
+    	if rateLimiter ~= nil then
+            -- TODO: create sendN instead of send or solve software-ratecontrol.lua#L29
+        	rateLimiter:send(bufs)
+    	else
+        	queue:sendN(bufs, n)
+    	end
+    end
 end
 

--- a/examples/rate-control-methods.lua
+++ b/examples/rate-control-methods.lua
@@ -11,11 +11,12 @@ local PKT_SIZE	= 60
 local ETH_DST	= "11:12:13:14:15:16"
 
 function master(txPort, rate, rc, pattern, threads)
-	if not txPort or not rate or not rc or (pattern ~= "cbr" and pattern ~= "poisson") then
-		return print("usage: txPort rate hw|sw|moongen cbr|poisson [threads]")
+	if not txPort or not rate or not rc then
+		return print("usage: txPort rate|us hw|sw|moongen cbr|poisson|custom [threads]")
 	end
 	rate = rate or 2
 	threads = threads or 1
+	pattern = pattern or "custom"
 	if pattern == "cbr" and threads ~= 1 then
 		return log:error("cbr only supports one thread")
 	end
@@ -56,6 +57,11 @@ function loadSlave(queue, txDev, rate, rc, pattern, rateLimiter, threadId, numTh
 		local bufs = mem:bufArray(128)
 		while mg.running() do
 			bufs:alloc(PKT_SIZE)
+			if pattern == "custom" then
+				for _, buf in ipairs(bufs) do
+					buf:setDelay(rate * txDev:getLinkStatus().speed / 8)
+				end
+			end
 			rateLimiter:send(bufs)
 		end
 	elseif rc == "moongen" then

--- a/src/software-rate-limiter.cpp
+++ b/src/software-rate-limiter.cpp
@@ -9,6 +9,7 @@
 #include <rte_cycles.h>
 #include <random>
 #include <iostream>
+#include <unistd.h>
 #include "ring.h"
 #include "lifecycle.hpp"
 
@@ -24,9 +25,42 @@
 // FIXME: duplicate code (needed for a paper, so the usual quick & dirty hacks)
 namespace rate_limiter {
 	constexpr int batch_size = 64;
-	
-	// FIXME: NYI
-	static inline void main_loop(struct rte_ring* ring, uint8_t device, uint16_t queue) {
+	/* Other option to make the end of this thread (based on time instead of the number of elements in the ring) */
+	//constexpr int seconds_without_packets = 5;
+
+	/*
+	 * Arbitrary time software rate control main
+	 * link_speed: DPDK link speed is expressed in Mbit/s
+	 */
+	static inline void main_loop(struct rte_ring* ring, uint8_t device, uint16_t queue, uint32_t link_speed) {
+		// Wait to slave thread while is filling the ring
+		sleep(1);
+		uint64_t tsc_hz = rte_get_tsc_hz();
+		uint64_t id_cycles = 0;
+		struct rte_mbuf* bufs[batch_size];
+		double link_bps = link_speed * 1000000.0;
+		uint64_t cur = rte_get_tsc_cycles();
+		uint64_t next_send = cur;
+		while (libmoon::is_running(0) && rte_ring_count(ring) > 0) {
+			//#L28:  && ((cur - next_send) < seconds_without_packets * tsc_hz)) {
+			int cur_batch_size = batch_size;
+			int rc = ring_dequeue(ring, reinterpret_cast<void**>(bufs), cur_batch_size);
+			while(rc != 0 && cur_batch_size > 1) {
+				cur_batch_size /= 2;
+				rc = ring_dequeue(ring, reinterpret_cast<void**>(bufs), cur_batch_size);
+			}
+		    if (rc == 0) {
+		    	for (int i = 0; i < cur_batch_size; i++) {
+		        	// desired inter-frame spacing is encoded in the hash 'usr' field (bytes)
+		            id_cycles = ((uint64_t) bufs[i]->udata64 * 8 / link_bps) * tsc_hz;
+		            next_send += id_cycles;
+		            while ((cur = rte_get_tsc_cycles()) < next_send); // waiting
+		            while (rte_eth_tx_burst(device, queue, bufs + i, 1) == 0);
+		        }
+		    }
+		    cur = rte_get_tsc_cycles();
+		}
+		return;
 	}
 	
 	static inline void main_loop_poisson(struct rte_ring* ring, uint8_t device, uint16_t queue, uint32_t target, uint32_t link_speed) {
@@ -94,9 +128,8 @@ extern "C" {
 		rate_limiter::main_loop_poisson(ring, device, queue, target, link_speed);
 	}
 
-	void mg_rate_limiter_main_loop(rte_ring* ring, uint8_t device, uint16_t queue) {
-		// NYI
-		//rate_limiter::main_loop(ring, device, queue);
+	void mg_rate_limiter_main_loop(rte_ring* ring, uint8_t device, uint16_t queue, uint32_t link_speed) {
+		rate_limiter::main_loop(ring, device, queue, link_speed);
 	}
 }
 


### PR DESCRIPTION
Add default software rate control to use arbitrary delays between packets.
Modify the rate-control example to show an example of this new rate control and modify replay-pcap to be able to use this rate limiter.