### PR TITLE
This fixes a segmentation fault if the pcap is too small.

### DIFF
--- a/examples/pcap/replay-pcap.lua
+++ b/examples/pcap/replay-pcap.lua
@@ -30,6 +30,7 @@ function master(args)
 end
 
 function replay(queue, file, loop, rateLimiter, multiplier)
+	log:info("[REPLAY]: Start Replay")
 	local mempool = memory:createMemPool(4096)
 	local bufs = mempool:bufArray()
 	local pcapFile = pcap:newReader(file)
@@ -43,6 +44,9 @@ function replay(queue, file, loop, rateLimiter, multiplier)
 					prev = bufs.array[0].udata64
 				end
 				for i, buf in ipairs(bufs) do
+					if buf == nil then
+						break
+					end
 					-- ts is in microseconds
 					local ts = buf.udata64
 					if prev > ts then


### PR DESCRIPTION
Hi @emmericp, 

during my testing with small pcaps (containing only the TCP handshake) I found that the replay-pcap example crashes Moongen with a SegFault. With this change this should not happen (at least this is the simplest change to mitigate it)