### PR TITLE
Fix example l3-tcp-syn-flood

### DIFF
--- a/examples/l3-tcp-syn-flood.lua
+++ b/examples/l3-tcp-syn-flood.lua
@@ -39,7 +39,7 @@ function loadSlave(queue, minA, numIPs, dest)
 	local mem = memory.createMemPool(function(buf)
 		buf:getTcpPacket(ipv4):fill{ 
 			ethSrc = queue,
-			ethDst = "12:34:56:78:90",
+			ethDst = "12:34:56:78:90:ab",
 			ip4Dst = dest, 
 			ip6Dst = dest,
 			tcpSyn = 1,


### PR DESCRIPTION
Fixed dst mac address in example. The Mac address was not complete,
it was replaced by 00:00:00:00:00:00. This address drops on Extreme
switches and traffic cannot leave the server port.