### PR TITLE
Fix multiple definition compile error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(MoonGen C CXX)
 
 #Options are defined in libmoon/CMakeLists.txt
 
-set(CMAKE_CXX_FLAGS "-fno-stack-protector -Wall -Wextra -Wno-unused-parameter -g -O3 -std=gnu++11 -march=native -msse4.2")
+set(CMAKE_CXX_FLAGS "-fno-stack-protector -Wall -Wextra -Wno-unused-parameter -g -O3 -std=gnu++11 -march=native -msse4.2 -Xlinker --allow-multiple-definition")
 set(CMAKE_C_FLAGS "-fno-stack-protector -Wall -Wextra -Wno-unused-parameter -g -O3 -std=gnu11 -march=native -msse4.2")
 set(CMAKE_EXE_LINKER_FLAGS "-rdynamic")
 


### PR DESCRIPTION
Newer versions of the C++ compiler treat multiple definitions as errors
during linking. This adds the linker option to ignore multiple definitions.
It should probably just be a temporary fix until the multiple definitions
in libmoon have been removed.

This fixes #322