### PR TITLE
Reset prev along with the pcap file in replay-pcap

### DIFF
--- a/examples/pcap/replay-pcap.lua
+++ b/examples/pcap/replay-pcap.lua
@@ -61,6 +61,7 @@ function replay(queue, file, loop, rateLimiter, multiplier, sleepTime)
 			end
 		else
 			if loop then
+				prev = 0
 				pcapFile:reset()
 			else
 				break
@@ -75,4 +76,3 @@ function replay(queue, file, loop, rateLimiter, multiplier, sleepTime)
 	log:info("Enqueued all packets, waiting for %d seconds for queues to flush", sleepTime)
 	mg.sleepMillisIdle(sleepTime * 1000)
 end
-


### PR DESCRIPTION
I'm pretty sure something like this is needed to avoid computing a reversed delay when looping a pcap file.

I haven't tested this implementation though, in the upcoming pull request for replay-pcap-multi i had to split off the pcap reading and sending part to a separate function replayonce to make the same thing work there.